### PR TITLE
chore: remove ihp130 from git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "scripts/foundry/ihp130"]
-	path = scripts/foundry/ihp130
-	url = https://github.com/IHP-GmbH/IHP-Open-PDK.git
-	branch = main


### PR DESCRIPTION
The pdk is not needed in the code, but it is too big for initialization.