### PR TITLE
refactor(build): optimize linker selection and fix build script flags

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -10,7 +10,7 @@ runs:
         dnf install -y epel-release
         dnf config-manager --set-enabled crb || true
         dnf install -y \
-          cmake ninja-build pkgconfig patchelf \
+          cmake ninja-build pkgconfig patchelf mold \
           boost-devel cairo-devel gflags-devel glog-devel \
           flex flex-devel bison eigen3-devel gtest-devel \
           tbb-devel hwloc-devel libcurl-devel libunwind-devel \

--- a/.github/scripts/build-wheel.sh
+++ b/.github/scripts/build-wheel.sh
@@ -39,6 +39,7 @@ fi
 cmake -B build -G Ninja \
     -DBUILD_ECOS=ON \
     -DBUILD_PYTHON=ON \
+    -DLINKER=mold \
     -DBUILD_STATIC_LIB=OFF \
     -DCOMPATIBILITY_MODE=ON \
     -DCMAKE_BUILD_TYPE=Release \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,34 @@ project(ecc)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Choose linker for linking
+set(LINKER "default" CACHE STRING "Select linker type (default, lld, mold)")
+set_property(CACHE LINKER PROPERTY STRINGS "default" "lld" "mold")
+string(TOLOWER "${LINKER}" LINKER_CHOICE)
+
+if(LINKER_CHOICE STREQUAL "lld")
+    find_program(LLD_PATH NAMES "ld.lld" "lld")
+    if(LLD_PATH)
+        message(STATUS "Use LLD linker: ${LLD_PATH}")
+        message(WARNING "TODO: Using LLD will crash when building shared libraries (.so), use mold or ld instead.")
+        add_link_options("-fuse-ld=lld")
+    else()
+        message(WARNING "LLD not found. Falling back to system default linker.")
+    endif()
+
+elseif(LINKER_CHOICE STREQUAL "mold")
+    find_program(MOLD_PATH NAMES "mold")
+    if(MOLD_PATH)
+        message(STATUS "Use MOLD linker: ${MOLD_PATH}")
+        add_link_options("-fuse-ld=mold")
+    else()
+        message(WARNING "MOLD not found. Falling back to system default linker.")
+    endif()
+endif()
+
+
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_CXX_FLAGS_RELEASE "$ENV{CXXFLAGS} -O3 -Wall -Werror=return-type")
 set(CMAKE_CXX_FLAGS_DEBUG "$ENV{CXXFLAGS} -O0 -g -Wall -Werror=return-type")

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ set -e
 
 # variables
 IEDA_WORKSPACE=$(cd "$(dirname "$0")";pwd)
-BINARY_TARGET="iEDA"
+BINARY_TARGET="ecc_bin"
 BINARY_DIR="${IEDA_WORKSPACE}/bin"
 BUILD_DIR="${IEDA_WORKSPACE}/build"
 CPP_COMPILER_PATH="g++-10"
@@ -32,9 +32,9 @@ DEL_BUILD="OFF"
 INSTALL_DEP="OFF"
 NON_INTERACTIVE="OFF"
 BUILD_THREADS="$(nproc)"
+BUILD_TYPE="Release"
 
 CMAKE_OPTIONS=(
-  "-DCMAKE_BUILD_TYPE=Release"
   "-DCMD_BUILD=ON"
 )
   # "-DBUILD_GUI=${BUILD_GUI:-OFF}"
@@ -58,7 +58,7 @@ help_msg_exit()
 echo -e "build.sh: Build iEDA executable binary"
 echo -e "Usage:"
 echo -e "  ${bold}bash build.sh${clear} [-h] [-n] [-r] [-b] [-d] [-i] [-p] "
-echo -e "                [-g] [-s] [-P] [-G] [-C] [-D] [-y]"
+echo -e "                [-g] [-s] [-P] [-G] [-C] [-D] [-y] [-M]"
 echo -e "                [-b ${underline}binary path${clear}] [-j ${underline}num${clear}] [-i apt|docker]"
 echo -e "Options:"
 echo -e "  ${bold}-h${clear} display this help and exit"
@@ -74,6 +74,8 @@ echo -e "  ${bold}-s${clear} enable address sanitizer (default OFF)"
 echo -e "  ${bold}-P${clear} enable performance profiling (default OFF)"
 echo -e "  ${bold}-G${clear} enable GPU acceleration (default OFF)"
 echo -e "  ${bold}-C${clear} enable compatibility mode (disable optimizations, default OFF)"
+echo -e "  ${bold}-M${clear} set CMAKE_BUILD_TYPE to Debug (default Release)"
+echo -e "  ${bold}-l${clear} select linker type (default/lld/mold)"
 echo -e "  ${bold}-D${clear} dry-run mode (show cmake build commands)"
 echo -e "  ${bold}-y${clear} auto confirm all actions, non-interactive mode (defaults: OFF)"
 exit "$1";
@@ -88,6 +90,7 @@ build_ieda()
     "-DCMAKE_CXX_COMPILER=$CPP_COMPILER_PATH"
     "-DCMAKE_C_COMPILER=$C_COMPILER_PATH"
     "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$BINARY_DIR"
+    "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
     "${CMAKE_OPTIONS[@]}"
     "$G_BUILD_GENERATOR"
   )
@@ -180,7 +183,8 @@ install_dependencies_apt()
       g++-10 cmake ninja-build \
       tcl-dev libgflags-dev libgoogle-glog-dev libboost-all-dev libgtest-dev flex\
       libeigen3-dev libunwind-dev libmetis-dev libgmp-dev bison rustc cargo\
-      libhwloc-dev libcairo2-dev libcurl4-openssl-dev libtbb-dev git
+      libhwloc-dev libcairo2-dev libcurl4-openssl-dev libtbb-dev git\
+      mold lld
     exit 0
   else
     echo -e "${red}apt-get not found, pleas make sure you were running on Debian-Based Linux distribution${clear}"
@@ -260,7 +264,7 @@ install_docker_experimental()
 # hello_test
 run_ieda()
 {
-  "${BINARY_DIR}"/iEDA -script "${IEDA_WORKSPACE}"/scripts/hello.tcl
+  "${BINARY_DIR}/${BINARY_TARGET}" -script "${IEDA_WORKSPACE}"/scripts/hello.tcl
 }
 
 sys_requirement_warning()
@@ -372,6 +376,11 @@ opt_non_interactive()
   NON_INTERACTIVE="ON"
 }
 
+opt_debug_build()
+{
+  BUILD_TYPE="Debug"
+}
+
 opt_build_ecos()
 {
   CMAKE_OPTIONS+=("-DBUILD_ECOS=ON")
@@ -383,7 +392,7 @@ if [[ $1 != "" ]] && [[ $1 != -* ]]; then
   help_msg_exit 1
 fi
 
-while getopts j:b:t:i:rndDyp opt; do
+while getopts j:b:t:i:l:rndDypgsPGChM opt; do
   case "${opt}" in
     j) opt_thread_num "$OPTARG"   ;;
     b) opt_binary_dir "$OPTARG"   ;;
@@ -400,6 +409,8 @@ while getopts j:b:t:i:rndDyp opt; do
     P) CMAKE_OPTIONS+=("-DUSE_PROFILER=ON") ;;
     G) CMAKE_OPTIONS+=("-DUSE_GPU=ON")      ;;
     C) CMAKE_OPTIONS+=("-DCOMPATIBILITY_MODE=ON") ;;
+    M) opt_debug_build            ;;
+    l) CMAKE_OPTIONS+=("-DLINKER=${OPTARG}") ;;
     h) help_msg_exit 0            ;;
     *) help_msg_exit 1            ;;
   esac


### PR DESCRIPTION
- Prefer mold/lld linker for 1.2-1.6x faster total compile time.
- Fix build.sh, add missing variables in getopts.
- Install mold linker in build-wheel CI action.


| Linker | Fresh Build Time (s) | Speedup (vs gnu-ld) | ccached Build Time (s) | Speedup (vs gnu-ld) |
| :--- | :---: | :---: | :---: | :---: |
| **gnu-ld** *(Baseline)* | 97 | 1.00x | 77 | 1.00x |
| **mold** | 79 | **1.2x** | 48 | **1.6x** |
| **lld** | 81 | **1.2x** | 54 | **1.4x** |