### PR TITLE
feat: add layout.csv for mapping

### DIFF
--- a/src/evaluation/CMakeLists.txt
+++ b/src/evaluation/CMakeLists.txt
@@ -12,3 +12,7 @@ add_subdirectory(${EVAL_API})
 #add_subdirectory(${EVAL_APPS})
 add_subdirectory(${EVAL_DATA})
 add_subdirectory(${EVAL_SOURCE})
+
+if(BUILD_TESTING)
+  add_subdirectory(${HOME_EVALUATION}/test)
+endif()

--- a/src/evaluation/src/module/congestion/CMakeLists.txt
+++ b/src/evaluation/src/module/congestion/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(eval_congestion_eval
 target_link_libraries(eval_congestion_eval
     PUBLIC
         eval_util_general_ops
+        eval_util_map_layout_writer
     PRIVATE
         idm
         eval_util_init_egr

--- a/src/evaluation/src/module/congestion/congestion_eval.cpp
+++ b/src/evaluation/src/module/congestion/congestion_eval.cpp
@@ -22,6 +22,7 @@
 #include "idm.h"
 #include "init_egr.h"
 #include "init_idb.h"
+#include "map_layout_writer.h"
 #include "wirelength_lut.h"
 
 namespace ieval {
@@ -30,6 +31,53 @@ namespace ieval {
 #define EVAL_INIT_IDB_INST (ieval::InitIDB::getInst())
 
 CongestionEval* CongestionEval::_congestion_eval = nullptr;
+
+namespace {
+std::vector<int32_t> parseCsvInts(const std::string& line)
+{
+  std::vector<int32_t> values;
+  std::istringstream iss(line);
+  std::string value;
+  while (std::getline(iss, value, ',')) {
+    if (!value.empty()) {
+      values.push_back(std::stoi(value));
+    }
+  }
+  return values;
+}
+
+void writeEGRLayoutCsv(const std::string& rt_dir_path, const std::string& map_dir, const std::vector<std::vector<double>>& matrix)
+{
+  if (matrix.empty() || matrix.front().empty()) {
+    return;
+  }
+
+  std::ifstream gcell_file(rt_dir_path + "/early_router/gcell.info");
+  if (!gcell_file.is_open()) {
+    return;
+  }
+
+  const int32_t matrix_rows = static_cast<int32_t>(matrix.size());
+  const int32_t matrix_cols = static_cast<int32_t>(matrix.front().size());
+  std::vector<MapLayoutCell> cells;
+  std::string line;
+  while (std::getline(gcell_file, line)) {
+    std::vector<int32_t> row = parseCsvInts(line);
+    if (row.size() < 6) {
+      continue;
+    }
+
+    int32_t grid_x = row[0];
+    int32_t grid_y = row[1];
+    if (grid_x < 0 || grid_x >= matrix_rows || grid_y < 0 || grid_y >= matrix_cols) {
+      continue;
+    }
+    cells.push_back({grid_x, grid_y, grid_x, grid_y, row[2], row[3], row[4], row[5]});
+  }
+
+  writeMapLayoutCsv(map_dir, cells);
+}
+}  // namespace
 
 CongestionEval::CongestionEval()
 {
@@ -237,7 +285,8 @@ string CongestionEval::evalEGR(string rt_dir_path, string egr_type, string outpu
   }
 
   std::string save_dir = "/egr_congestion_map";
-  std::string output_path = createDirPath(save_dir) + "/" + output_filename;
+  std::string map_dir = createDirPath(save_dir);
+  std::string output_path = map_dir + "/" + output_filename;
 
   std::ofstream out_file(output_path);
   for (const auto& row : sum_matrix) {
@@ -250,6 +299,7 @@ string CongestionEval::evalEGR(string rt_dir_path, string egr_type, string outpu
     out_file << "\n";
   }
   out_file.close();
+  writeEGRLayoutCsv(rt_dir_path, map_dir, sum_matrix);
 
   return output_path;
 }
@@ -332,7 +382,8 @@ string CongestionEval::evalRUDY(CongestionNets nets, CongestionRegion region, in
   }
 
   std::string save_dir = "/RUDY_map";
-  std::string output_path = createDirPath(save_dir) + "/" + output_filename;
+  std::string map_dir = createDirPath(save_dir);
+  std::string output_path = map_dir + "/" + output_filename;
   std::ofstream csv_file(output_path);
 
   for (size_t row_index = density_grid.size(); row_index-- > 0;) {
@@ -346,6 +397,7 @@ string CongestionEval::evalRUDY(CongestionNets nets, CongestionRegion region, in
   }
 
   csv_file.close();
+  writeMapLayoutCsv(map_dir, grid_cols, grid_rows, grid_size, region.lx, region.ly, region.ux, region.uy);
 
   return getAbsoluteFilePath(output_path);
 }
@@ -451,7 +503,8 @@ string CongestionEval::evalLUTRUDY(CongestionNets nets, CongestionRegion region,
   }
 
   std::string save_dir = "/RUDY_map";
-  std::string output_path = createDirPath(save_dir) + "/" + output_filename;
+  std::string map_dir = createDirPath(save_dir);
+  std::string output_path = map_dir + "/" + output_filename;
   std::ofstream csv_file(output_path);
 
   for (size_t row_index = density_grid.size(); row_index-- > 0;) {
@@ -465,6 +518,7 @@ string CongestionEval::evalLUTRUDY(CongestionNets nets, CongestionRegion region,
   }
 
   csv_file.close();
+  writeMapLayoutCsv(map_dir, grid_cols, grid_rows, grid_size, region.lx, region.ly, region.ux, region.uy);
 
   return getAbsoluteFilePath(output_path);
 }

--- a/src/evaluation/src/module/density/CMakeLists.txt
+++ b/src/evaluation/src/module/density/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(eval_density_eval
 target_link_libraries(eval_density_eval
     PUBLIC
         eval_util_general_ops
+        eval_util_map_layout_writer
     PRIVATE
         eval_util_init_idb
 )

--- a/src/evaluation/src/module/density/density_eval.cpp
+++ b/src/evaluation/src/module/density/density_eval.cpp
@@ -18,6 +18,7 @@
 
 #include "general_ops.h"
 #include "init_idb.h"
+#include "map_layout_writer.h"
 
 namespace ieval {
 
@@ -157,7 +158,8 @@ std::string DensityEval::evalDensity(DensityCells cells, DensityRegion region, i
   }
 
   std::string save_dir = "/density_map";
-  std::string output_path = createDirPath(save_dir) + "/" + output_filename;
+  std::string map_dir = createDirPath(save_dir);
+  std::string output_path = map_dir + "/" + output_filename;
   std::ofstream csv_file(output_path);
 
   for (size_t row_index = density_grid.size(); row_index-- > 0;) {
@@ -171,6 +173,7 @@ std::string DensityEval::evalDensity(DensityCells cells, DensityRegion region, i
   }
 
   csv_file.close();
+  writeMapLayoutCsv(map_dir, grid_cols, grid_rows, grid_size, region.lx, region.ly, region.ux, region.uy);
 
   return getAbsoluteFilePath(output_path);
 }
@@ -244,11 +247,12 @@ std::string DensityEval::evalPinDensity(DensityPins pins, DensityRegion region, 
   }
 
   std::string save_dir="/density_map";
+  std::string map_dir = createDirPath(save_dir);
   std::string output_path;
   if (neighbor) {
-    output_path = createDirPath(save_dir) + "/" + "neighbor_" + output_filename;
+    output_path = map_dir + "/" + "neighbor_" + output_filename;
   } else {
-    output_path = createDirPath(save_dir) + "/" + output_filename;
+    output_path = map_dir + "/" + output_filename;
   }
 
   std::ofstream csv_file(output_path);
@@ -264,6 +268,7 @@ std::string DensityEval::evalPinDensity(DensityPins pins, DensityRegion region, 
   }
 
   csv_file.close();
+  writeMapLayoutCsv(map_dir, grid_cols, grid_rows, grid_size, region.lx, region.ly, region.ux, region.uy);
 
   return getAbsoluteFilePath(output_path);
 }
@@ -304,6 +309,7 @@ std::string DensityEval::evalNetDensity(DensityNets nets, DensityRegion region, 
   }
 
   std::string save_dir="/density_map";
+  std::string map_dir = createDirPath(save_dir);
   std::string output_path;
   if (neighbor) {
     const std::vector<std::vector<int>> kernel = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
@@ -325,7 +331,7 @@ std::string DensityEval::evalNetDensity(DensityNets nets, DensityRegion region, 
         neighbor_net_count[row][col] = sum;
       }
     }
-    output_path = createDirPath(save_dir) + "/" + "neighbor_" + output_filename;
+    output_path = map_dir + "/" + "neighbor_" + output_filename;
     std::ofstream csv_file(output_path);
     for (int32_t row = grid_rows - 1; row >= 0; --row) {
       for (int32_t col = 0; col < grid_cols; ++col) {
@@ -340,7 +346,7 @@ std::string DensityEval::evalNetDensity(DensityNets nets, DensityRegion region, 
   }
 
   else {
-    output_path = createDirPath(save_dir) + "/" + output_filename;
+    output_path = map_dir + "/" + output_filename;
     std::ofstream csv_file(output_path);
     for (int32_t row = grid_rows - 1; row >= 0; --row) {
       for (int32_t col = 0; col < grid_cols; ++col) {
@@ -362,6 +368,7 @@ std::string DensityEval::evalNetDensity(DensityNets nets, DensityRegion region, 
     }
     csv_file.close();
   }
+  writeMapLayoutCsv(map_dir, grid_cols, grid_rows, grid_size, region.lx, region.ly, region.ux, region.uy);
 
   return getAbsoluteFilePath(output_path);
 }
@@ -443,7 +450,8 @@ std::string DensityEval::evalMargin(DensityCells cells, DensityRegion die, Densi
   }
 
   std::string save_dir="/margin_map";
-  std::string output_path = createDirPath(save_dir) + "/" + output_filename;
+  std::string map_dir = createDirPath(save_dir);
+  std::string output_path = map_dir + "/" + output_filename;
   std::ofstream csv_file(output_path);
 
   int32_t grid_cols = (die.ux - die.lx + grid_size - 1) / grid_size;
@@ -459,6 +467,7 @@ std::string DensityEval::evalMargin(DensityCells cells, DensityRegion die, Densi
   }
 
   csv_file.close();
+  writeMapLayoutCsv(map_dir, grid_cols, grid_rows, grid_size, die.lx, die.ly, die.ux, die.uy);
 
   return getAbsoluteFilePath(output_path);
 }

--- a/src/evaluation/src/util/CMakeLists.txt
+++ b/src/evaluation/src/util/CMakeLists.txt
@@ -15,6 +15,16 @@ target_include_directories(eval_util_general_ops
         ${EVAL_UTIL}
 )
 
+# map layout writer
+add_library(eval_util_map_layout_writer
+    ${EVAL_UTIL}/map_layout_writer.cpp
+)
+
+target_include_directories(eval_util_map_layout_writer
+    PUBLIC
+        ${EVAL_UTIL}
+)
+
 # iRT-egr
 add_library(eval_util_init_egr
     ${EVAL_UTIL}/init_egr.cpp

--- a/src/evaluation/src/util/map_layout_writer.cpp
+++ b/src/evaluation/src/util/map_layout_writer.cpp
@@ -1,0 +1,65 @@
+/*
+ * @FilePath: map_layout_writer.cpp
+ * @Author: Yihang Qiu (qiuyihang23@mails.ucas.ac.cn)
+ * @Date: 2026-07-08
+ * @Description:
+ */
+
+#include "map_layout_writer.h"
+
+#include <algorithm>
+#include <fstream>
+
+namespace ieval {
+
+namespace {
+bool writeCells(const std::string& map_dir, const std::vector<MapLayoutCell>& cells)
+{
+  if (map_dir.empty() || cells.empty()) {
+    return false;
+  }
+
+  std::ofstream layout_file(map_dir + "/layout.csv");
+  if (!layout_file.is_open()) {
+    return false;
+  }
+
+  layout_file << "pixel_row,pixel_col,grid_x,grid_y,lx,ly,ux,uy\n";
+  for (const MapLayoutCell& cell : cells) {
+    layout_file << cell.pixel_row << "," << cell.pixel_col << "," << cell.grid_x << "," << cell.grid_y << "," << cell.lx << ","
+                << cell.ly << "," << cell.ux << "," << cell.uy << "\n";
+  }
+
+  return true;
+}
+}  // namespace
+
+bool writeMapLayoutCsv(const std::string& map_dir, int32_t grid_cols, int32_t grid_rows, int32_t grid_size, int32_t lx, int32_t ly,
+                       int32_t ux, int32_t uy)
+{
+  if (map_dir.empty() || grid_cols <= 0 || grid_rows <= 0 || grid_size <= 0 || lx >= ux || ly >= uy) {
+    return false;
+  }
+
+  std::vector<MapLayoutCell> cells;
+  cells.reserve(static_cast<size_t>(grid_cols) * static_cast<size_t>(grid_rows));
+  for (int32_t pixel_row = 0; pixel_row < grid_rows; ++pixel_row) {
+    int32_t grid_row = grid_rows - 1 - pixel_row;
+    for (int32_t grid_col = 0; grid_col < grid_cols; ++grid_col) {
+      int32_t grid_lx = lx + grid_col * grid_size;
+      int32_t grid_ly = ly + grid_row * grid_size;
+      int32_t grid_ux = std::min(lx + (grid_col + 1) * grid_size, ux);
+      int32_t grid_uy = std::min(ly + (grid_row + 1) * grid_size, uy);
+      cells.push_back({pixel_row, grid_col, grid_col, grid_row, grid_lx, grid_ly, grid_ux, grid_uy});
+    }
+  }
+
+  return writeCells(map_dir, cells);
+}
+
+bool writeMapLayoutCsv(const std::string& map_dir, const std::vector<MapLayoutCell>& cells)
+{
+  return writeCells(map_dir, cells);
+}
+
+}  // namespace ieval

--- a/src/evaluation/src/util/map_layout_writer.h
+++ b/src/evaluation/src/util/map_layout_writer.h
@@ -1,0 +1,32 @@
+/*
+ * @FilePath: map_layout_writer.h
+ * @Author: Yihang Qiu (qiuyihang23@mails.ucas.ac.cn)
+ * @Date: 2026-07-08
+ * @Description:
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace ieval {
+
+struct MapLayoutCell
+{
+  int32_t pixel_row;
+  int32_t pixel_col;
+  int32_t grid_x;
+  int32_t grid_y;
+  int32_t lx;
+  int32_t ly;
+  int32_t ux;
+  int32_t uy;
+};
+
+bool writeMapLayoutCsv(const std::string& map_dir, int32_t grid_cols, int32_t grid_rows, int32_t grid_size, int32_t lx, int32_t ly,
+                       int32_t ux, int32_t uy);
+bool writeMapLayoutCsv(const std::string& map_dir, const std::vector<MapLayoutCell>& cells);
+
+}  // namespace ieval

--- a/src/evaluation/test/CMakeLists.txt
+++ b/src/evaluation/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_executable(eval_map_layout_writer_test
+    map_layout_writer_test.cpp
+)
+
+target_link_libraries(eval_map_layout_writer_test
+    PRIVATE
+        eval_util_map_layout_writer
+)
+
+add_test(NAME eval_map_layout_writer_test COMMAND eval_map_layout_writer_test)
+
+add_executable(eval_map_layout_reference_replay
+    map_layout_reference_replay.cpp
+)
+
+target_link_libraries(eval_map_layout_reference_replay
+    PRIVATE
+        ieda_feature
+        idm
+)
+
+set(EVAL_MAP_LAYOUT_REFERENCE_WORKSPACE
+    ${CMAKE_BINARY_DIR}/ecc-runs/ecos-ecc-cli-gcd-ics55-20260708-133807/workspace/place_dreamplace)
+if(EXISTS ${EVAL_MAP_LAYOUT_REFERENCE_WORKSPACE}/output/gcd_place.def.gz)
+    add_test(NAME eval_map_layout_reference_replay COMMAND eval_map_layout_reference_replay ${EVAL_MAP_LAYOUT_REFERENCE_WORKSPACE})
+endif()

--- a/src/evaluation/test/map_layout_reference_replay.cpp
+++ b/src/evaluation/test/map_layout_reference_replay.cpp
@@ -1,0 +1,218 @@
+#include "feature_manager.h"
+#include "idm.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+struct MatrixShape
+{
+  int32_t rows = 0;
+  int32_t cols = 0;
+};
+
+std::string readText(const fs::path& path)
+{
+  std::ifstream file(path, std::ios::binary);
+  if (!file.is_open()) {
+    throw std::runtime_error("failed to open: " + path.string());
+  }
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+MatrixShape readCsvShape(const fs::path& csv_path)
+{
+  std::ifstream file(csv_path);
+  if (!file.is_open()) {
+    throw std::runtime_error("failed to open csv: " + csv_path.string());
+  }
+
+  std::string line;
+  MatrixShape shape;
+  while (std::getline(file, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    int32_t cols = 1;
+    for (char ch : line) {
+      if (ch == ',') {
+        ++cols;
+      }
+    }
+    if (shape.cols == 0) {
+      shape.cols = cols;
+    } else if (shape.cols != cols) {
+      throw std::runtime_error("ragged csv: " + csv_path.string());
+    }
+    ++shape.rows;
+  }
+  if (shape.rows <= 0 || shape.cols <= 0) {
+    throw std::runtime_error("empty csv: " + csv_path.string());
+  }
+  return shape;
+}
+
+int64_t countLines(const fs::path& path)
+{
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    throw std::runtime_error("failed to open: " + path.string());
+  }
+  return std::count(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>(), '\n');
+}
+
+fs::path firstMapCsv(const fs::path& dir)
+{
+  std::vector<fs::path> csv_files;
+  for (const auto& entry : fs::directory_iterator(dir)) {
+    if (entry.path().extension() == ".csv" && entry.path().filename() != "layout.csv") {
+      csv_files.push_back(entry.path());
+    }
+  }
+  std::sort(csv_files.begin(), csv_files.end());
+  if (csv_files.empty()) {
+    throw std::runtime_error("no map csv in: " + dir.string());
+  }
+  return csv_files.front();
+}
+
+std::vector<fs::path> mapCsvFiles(const fs::path& dir)
+{
+  std::vector<fs::path> csv_files;
+  for (const auto& entry : fs::directory_iterator(dir)) {
+    if (entry.path().extension() == ".csv" && entry.path().filename() != "layout.csv") {
+      csv_files.push_back(entry.path().filename());
+    }
+  }
+  std::sort(csv_files.begin(), csv_files.end());
+  return csv_files;
+}
+
+void requireExists(const fs::path& path)
+{
+  if (!fs::exists(path)) {
+    throw std::runtime_error("missing required path: " + path.string());
+  }
+}
+
+void initDatabaseFromPlacedDef(const fs::path& workspace, const fs::path& generated_feature_dir)
+{
+  const fs::path config_path = workspace.parent_path() / "config" / "db_default_config.json";
+  const fs::path def_path = workspace / "output" / "gcd_place.def.gz";
+  requireExists(config_path);
+  requireExists(def_path);
+
+  dmInst->reset();
+  if (!dmInst->readLef(config_path.string())) {
+    throw std::runtime_error("failed to read LEF from config: " + config_path.string());
+  }
+
+  dmInst->get_config().set_def_path(def_path.string());
+  dmInst->get_config().set_feature_path(generated_feature_dir.string());
+  dmInst->get_config().set_output_path((generated_feature_dir.parent_path() / "output").string());
+  if (!dmInst->readDef(def_path.string())) {
+    throw std::runtime_error("failed to read DEF: " + def_path.string());
+  }
+}
+
+int32_t inferFeatureGridSize(const fs::path& workspace)
+{
+  const MatrixShape reference_shape = readCsvShape(firstMapCsv(workspace / "feature" / "density_map"));
+  const int32_t die_width = dmInst->get_idb_layout()->get_die()->get_bounding_box()->get_width();
+  const int32_t row_height = dmInst->get_idb_layout()->get_rows()->get_row_height();
+  if (reference_shape.cols <= 0 || die_width <= 0 || row_height <= 0) {
+    throw std::runtime_error("failed to infer feature grid size from reference density map");
+  }
+
+  const double effective_grid = static_cast<double>(die_width) / static_cast<double>(reference_shape.cols);
+  return std::max(1, static_cast<int32_t>(std::llround(effective_grid / row_height)));
+}
+
+void regenerateMaps(const fs::path& workspace, const fs::path& generated_feature_dir)
+{
+  fs::remove_all(generated_feature_dir.parent_path());
+  fs::create_directories(generated_feature_dir);
+
+  initDatabaseFromPlacedDef(workspace, generated_feature_dir);
+
+  const int32_t grid_size = inferFeatureGridSize(workspace);
+  if (!featureInst->save_pl_eval((generated_feature_dir / "place.map.json").string(), grid_size)) {
+    throw std::runtime_error("FeatureManager::save_pl_eval failed");
+  }
+}
+
+void compareMapDirectory(const fs::path& reference_dir, const fs::path& generated_dir)
+{
+  requireExists(generated_dir / "layout.csv");
+
+  const MatrixShape shape = readCsvShape(firstMapCsv(generated_dir));
+  const int64_t expected_layout_lines = static_cast<int64_t>(shape.rows) * shape.cols + 1;
+  const int64_t actual_layout_lines = countLines(generated_dir / "layout.csv");
+  if (actual_layout_lines != expected_layout_lines) {
+    throw std::runtime_error("layout line count mismatch: " + generated_dir.string());
+  }
+
+  const std::vector<fs::path> reference_maps = mapCsvFiles(reference_dir);
+  const std::vector<fs::path> generated_maps = mapCsvFiles(generated_dir);
+  if (reference_maps != generated_maps) {
+    throw std::runtime_error("generated map file list differs from reference: " + generated_dir.string());
+  }
+
+  for (const fs::path& csv_name : reference_maps) {
+    const fs::path reference_csv = reference_dir / csv_name;
+    const fs::path generated_csv = generated_dir / csv_name;
+    if (readText(reference_csv) != readText(generated_csv)) {
+      throw std::runtime_error("map csv differs from reference: " + generated_csv.string());
+    }
+  }
+}
+
+void verifyReplay(const fs::path& workspace, const fs::path& generated_feature_dir)
+{
+  const fs::path reference_feature_dir = workspace / "feature";
+  const std::vector<std::string> map_dirs = {"density_map", "RUDY_map", "margin_map", "egr_congestion_map"};
+  for (const std::string& map_dir : map_dirs) {
+    compareMapDirectory(reference_feature_dir / map_dir, generated_feature_dir / map_dir);
+  }
+}
+}  // namespace
+
+int main(int argc, char** argv)
+{
+  fs::path workspace;
+  if (argc >= 2) {
+    workspace = argv[1];
+  } else {
+    workspace = fs::current_path() / "ecc-runs" / "ecos-ecc-cli-gcd-ics55-20260708-133807" / "workspace" / "place_dreamplace";
+  }
+
+  fs::path generated_feature_dir;
+  if (argc >= 3) {
+    generated_feature_dir = argv[2];
+  } else {
+    generated_feature_dir = fs::current_path() / "verify" / "eval_map_layout_reference_replay" / "place_dreamplace_feature";
+  }
+
+  try {
+    regenerateMaps(workspace, generated_feature_dir);
+    verifyReplay(workspace, generated_feature_dir);
+  } catch (const std::exception& error) {
+    std::cerr << error.what() << "\n";
+    return 1;
+  }
+
+  std::cout << "map replay ok: " << generated_feature_dir << "\n";
+  return 0;
+}

--- a/src/evaluation/test/map_layout_writer_test.cpp
+++ b/src/evaluation/test/map_layout_writer_test.cpp
@@ -1,0 +1,75 @@
+#include "map_layout_writer.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+std::vector<std::string> readLines(const std::filesystem::path& path)
+{
+  std::ifstream file(path);
+  std::vector<std::string> lines;
+  std::string line;
+  while (std::getline(file, line)) {
+    lines.push_back(line);
+  }
+  return lines;
+}
+
+void expectEqual(const std::string& actual, const std::string& expected, const std::string& message)
+{
+  if (actual != expected) {
+    std::cerr << message << "\nexpected: " << expected << "\nactual:   " << actual << "\n";
+    std::exit(1);
+  }
+}
+}  // namespace
+
+int main()
+{
+  const std::filesystem::path out_dir = std::filesystem::temp_directory_path() / "ecc_eval_layout_writer_test";
+  std::filesystem::remove_all(out_dir);
+  std::filesystem::create_directories(out_dir);
+
+  const bool ok = ieval::writeMapLayoutCsv(out_dir.string(), 3, 2, 10, 100, 200, 125, 218);
+  if (!ok) {
+    std::cerr << "writeMapLayoutCsv returned false\n";
+    return 1;
+  }
+
+  const auto lines = readLines(out_dir / "layout.csv");
+  if (lines.size() != 7) {
+    std::cerr << "expected header plus 6 layout rows, got " << lines.size() << "\n";
+    return 1;
+  }
+
+  expectEqual(lines[0], "pixel_row,pixel_col,grid_x,grid_y,lx,ly,ux,uy", "header mismatch");
+  expectEqual(lines[1], "0,0,0,1,100,210,110,218", "top-left pixel should map to highest grid y");
+  expectEqual(lines[3], "0,2,2,1,120,210,125,218", "last column should clamp ux to region ux");
+  expectEqual(lines[4], "1,0,0,0,100,200,110,210", "second pixel row should map to bottom grid y");
+  expectEqual(lines[6], "1,2,2,0,120,200,125,210", "bottom-right pixel bbox mismatch");
+
+  const std::vector<ieval::MapLayoutCell> gcell_layout = {
+      {.pixel_row = 0, .pixel_col = 0, .grid_x = 0, .grid_y = 7, .lx = 10, .ly = 30, .ux = 20, .uy = 40},
+      {.pixel_row = 0, .pixel_col = 1, .grid_x = 1, .grid_y = 7, .lx = 20, .ly = 30, .ux = 35, .uy = 40},
+  };
+  const std::filesystem::path gcell_dir = out_dir / "egr";
+  std::filesystem::create_directories(gcell_dir);
+  if (!ieval::writeMapLayoutCsv(gcell_dir.string(), gcell_layout)) {
+    std::cerr << "writeMapLayoutCsv for explicit cells returned false\n";
+    return 1;
+  }
+  const auto gcell_lines = readLines(gcell_dir / "layout.csv");
+  if (gcell_lines.size() != 3) {
+    std::cerr << "expected header plus 2 gcell rows, got " << gcell_lines.size() << "\n";
+    return 1;
+  }
+  expectEqual(gcell_lines[1], "0,0,0,7,10,30,20,40", "explicit gcell row 0 mismatch");
+  expectEqual(gcell_lines[2], "0,1,1,7,20,30,35,40", "explicit gcell row 1 mismatch");
+
+  std::filesystem::remove_all(out_dir);
+  return 0;
+}


### PR DESCRIPTION
Summary:
  - Add map layout CSV writer utility.
  - Emit layout.csv from congestion and density evaluation flows.
  - Add unit/reference replay tests for layout mapping output.
