### PR TITLE
fix(pyplacedb): classify located hard macros as fixed

### DIFF
--- a/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.cpp
+++ b/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.cpp
@@ -78,7 +78,7 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
   std::map<std::string, index_type> mNode2idbID;
   std::vector<IdbInstance*> inst_resort_list = db_deisgn->get_instance_list()->get_instance_list();
   std::stable_sort(inst_resort_list.begin(), inst_resort_list.end(),
-                   [](IdbInstance* a, IdbInstance* b) { return a->is_fixed() < b->is_fixed(); });
+                   [](IdbInstance* a, IdbInstance* b) { return isPlacementFixed(a) < isPlacementFixed(b); });
   for (IdbInstance* node : inst_resort_list) {
     mNode2idbID[node->get_name()] = node->get_id();
   }
@@ -163,7 +163,7 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
     if (node->get_cell_master()->is_block()) {
       ECCLOG.info(ecc::Loc::current(), "Node ", node->get_name(), " is a block.");
     }
-    if (node->get_status() != IdbPlacementStatus::kFixed) {
+    if (!isPlacementFixed(node)) {
       Box box_tmp = buildInstanceBox(node);
       if (node->get_halo()) {
         // Jiaqi: add halo for fixed cells
@@ -373,7 +373,7 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
       assert(mNet2ID.count(pin->get_net()->get_net_name()));
       pin2net_map.append(mNet2ID[pin->get_net()->get_net_name()]);
 
-      if (node->get_status() != IdbPlacementStatus::kFixed /*&& node.status() != PlaceStatusEnum::DUMMY_FIXED*/) {
+      if (!isPlacementFixed(node) /*&& node.status() != PlaceStatusEnum::DUMMY_FIXED*/) {
         num_movable_pins += 1;
       }
     }
@@ -485,7 +485,7 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
       for (IdbInstance* inst : region->get_instance_list()) {
         // FIXME:
         index_type node_id = mNode2PyNondeID[inst->get_name()];
-        if (inst->get_status() != IdbPlacementStatus::kFixed)  // ignore fixed cells
+        if (!isPlacementFixed(inst))  // ignore fixed cells
         {
           vNode2FenceRegion.at(node_id) = region_id;
         }

--- a/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.h
+++ b/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.h
@@ -35,6 +35,19 @@ double intersectArea(Box const& b1, Box const& b2);
 bool isInvailidNet(IdbNet* net);
 
 std::string IdbOrientToString(IdbOrient orient);
+
+inline bool isPlacementFixed(idb::IdbInstance* node)
+{
+  const auto status = node->get_status();
+  if (status == idb::IdbPlacementStatus::kFixed) {
+    return true;
+  }
+
+  auto* cell_master = node->get_cell_master();
+  return cell_master != nullptr && cell_master->is_block()
+         && (status == idb::IdbPlacementStatus::kPlaced || status == idb::IdbPlacementStatus::kCover);
+}
+
 /// database for python
 struct PyPlaceDB
 {

--- a/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDBRoutbility.cpp
+++ b/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDBRoutbility.cpp
@@ -96,7 +96,7 @@ void PyPlaceDB::init_routability(idm::DataManager* db, std::vector<IdbInstance*>
     // else if (macro.className() != "DREAMPlace.PlaceBlockage") // fixed cells are special cases, skip placement blockages (looks like
     // ISPD2015 benchmarks do not process placement blockages)
 
-    if (node->get_status() == IdbPlacementStatus::kFixed) {
+    if (isPlacementFixed(node)) {
       // Macro const& macro = db.macro(db.macroId(node));
       // ECCLOG.info(ecc::Loc::current(), "PyPlaceDB detects fixed cell.");
       for (auto obs : node->get_cell_master()->get_obs_list()) {


### PR DESCRIPTION
## Summary

- Treat fixed, placed hard macro, and cover hard macro instances as fixed placement terminals.
- Keep unplaced hard macros and ordinary placed standard cells movable.
- Apply the same classification to node sorting, movable pin accounting, fence regions, and routability obstructions.

## Validation

- Built the ecc_py target successfully.
- Ran the ECC PyPlaceDB macro-status regression successfully (1 passed).
- Verified the staged patch with git diff --check.