### PR TITLE
fix(pyplacedb): block placement outside rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ test/**
 !test/support.py
 !test/data/
 !test/data/test_python_io.py
+!test/data/test_pyplacedb_rows.py
 !test/operations/
 !test/operations/test_python_operations.py
 !test/fixtures/

--- a/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.cpp
+++ b/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.cpp
@@ -245,6 +245,19 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
     blockage_ps_list += ps;
   }
   auto core = db->get_idb_layout()->get_core();
+  IdbRect* core_rect = core->get_bounding_box();
+  auto core_box = gtl::rectangle_data<coordinate_type>(core_rect->get_low_x(), core_rect->get_low_y(), core_rect->get_high_x(),
+                                                       core_rect->get_high_y());
+  PolygonSet row_ps;
+  for (IdbRow* idb_row : db->get_idb_layout()->get_rows()->get_row_list()) {
+    IdbRect* row_rect = idb_row->get_bounding_box();
+    row_ps.insert(
+        gtl::rectangle_data<coordinate_type>(row_rect->get_low_x(), row_rect->get_low_y(), row_rect->get_high_x(), row_rect->get_high_y()));
+  }
+  row_ps &= core_box;
+  PolygonSet no_row_ps;
+  no_row_ps.insert(core_box);
+  no_row_ps -= row_ps;
   row_height = db->get_idb_layout()->get_rows()->get_row_height();
   auto second_routing_layer = db->get_idb_layout()->get_layers()->get_routing_layers().at(1);
   assert(second_routing_layer->get_name().find("2") != std::string::npos);
@@ -274,13 +287,15 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
     }
   }
 #endif
-  // Union all hard obstacles before decomposition.  Subtract only the fixed
-  // body union: halo area outside the body must remain unavailable, while any
-  // overlap between halos, blockages, and bodies is represented exactly once.
+  // Union all hard obstacles before decomposition.  Areas inside the core
+  // without placement rows are unavailable even when the DEF has no explicit
+  // HALO or placement blockage.  Subtract fixed bodies because they are
+  // already represented by their real instance terminals.
   PolygonSet fixed_body_ps(gtl::HORIZONTAL, fixed_body_boxes.begin(), fixed_body_boxes.end());
   PolygonSet fixed_halo_ps(gtl::HORIZONTAL, fixed_halo_boxes.begin(), fixed_halo_boxes.end());
   PolygonSet obstacle_ps = blockage_ps_list;
   obstacle_ps += fixed_halo_ps;
+  obstacle_ps += no_row_ps;
   obstacle_ps -= fixed_body_ps;
   int ext_blockage_num = 0;
 
@@ -326,9 +341,6 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
   // represented by the terminal rectangles above.
   PolygonSet ps(gtl::HORIZONTAL, fixed_boxes.begin(), fixed_boxes.end());
   // critical to make sure only overlap with the die area is computed
-  IdbRect* core_rect = db->get_idb_layout()->get_core()->get_bounding_box();
-  auto core_box = gtl::rectangle_data<coordinate_type>(core_rect->get_low_x(), core_rect->get_low_y(), core_rect->get_high_x(),
-                                                       core_rect->get_high_y());
   ps &= core_box;
   double total_fixed_geometry_area = gtl::area(ps);
   total_space_area = core_rect->get_area() - total_fixed_geometry_area;
@@ -339,10 +351,10 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
   halo_core_ps &= core_box;
   PolygonSet residual_obstacle_core_ps(gtl::HORIZONTAL, vRect.begin(), vRect.end());
   residual_obstacle_core_ps &= core_box;
-  ECCLOG.info(ecc::Loc::current(), "PyPlaceDB fixed geometry: body_union_area ", gtl::area(body_core_ps),
-               ", halo_union_area ", gtl::area(halo_core_ps), ", residual_obstacle_area ",
-               gtl::area(residual_obstacle_core_ps), ", terminal_union_area ", total_fixed_geometry_area,
-               ", terminal_area_sum ", total_fixed_node_area, ", synthetic_rectangles ", ext_blockage_num, ".");
+  ECCLOG.info(ecc::Loc::current(), "PyPlaceDB fixed geometry: body_union_area ", gtl::area(body_core_ps), ", halo_union_area ",
+              gtl::area(halo_core_ps), ", no_row_area ", gtl::area(no_row_ps), ", residual_obstacle_area ",
+              gtl::area(residual_obstacle_core_ps), ", terminal_union_area ", total_fixed_geometry_area, ", terminal_area_sum ",
+              total_fixed_node_area, ", synthetic_rectangles ", ext_blockage_num, ".");
   int count = 0;
   for (int i = 0; i < mNode2PyNondeID.size() - num_terminal_NIs - ext_blockage_num; ++i) {
     auto node_name = node_names[i].cast<std::string>();

--- a/test/data/test_pyplacedb_rows.py
+++ b/test/data/test_pyplacedb_rows.py
@@ -1,0 +1,18 @@
+import json
+
+from support import assert_nonempty_file, run_scenario
+
+
+def test_pyplacedb_converts_missing_row_area_to_fixed_blockage(test_roots):
+    result = run_scenario(test_roots, "pyplacedb_rows", timeout=120)
+    summary = result.output_path("summary")
+    assert_nonempty_file(summary)
+    assert json.loads(summary.read_text(encoding="utf-8")) == {
+        "blockages": [[4000, 0, 2000, 1400]],
+        "num_terminals": 1,
+        "rows": [
+            [0, 0, 4000, 1400],
+            [6000, 0, 10000, 1400],
+            [0, 1400, 10000, 2800],
+        ],
+    }

--- a/test/native_scenarios.py
+++ b/test/native_scenarios.py
@@ -2,6 +2,7 @@ import json
 import shutil
 import sys
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
 
 from ecc_tools_bin import ecc_py
@@ -55,6 +56,58 @@ def def_verify(manifest: dict[str, Any]) -> dict[str, Path]:
     _setup(manifest)
     _read_design(manifest)
     return {}
+
+
+def pyplacedb_rows(manifest: dict[str, Any]) -> dict[str, Path]:
+    _setup(manifest)
+    design_def = Path(manifest["work_dir"]) / "cut_rows.def"
+    design_def.write_text(
+        dedent(
+            """
+            VERSION 5.8 ;
+            DESIGN cut_rows ;
+            UNITS DISTANCE MICRONS 1000 ;
+            DIEAREA ( 0 0 ) ( 10000 2800 ) ;
+            ROW BOTTOM_LEFT core7 0 0 N DO 20 BY 1 STEP 200 0 ;
+            ROW BOTTOM_RIGHT core7 6000 0 N DO 20 BY 1 STEP 200 0 ;
+            ROW TOP core7 0 1400 FS DO 50 BY 1 STEP 200 0 ;
+            COMPONENTS 1 ;
+            - movable ADDFX1H7R + UNPLACED ;
+            END COMPONENTS
+            PINS 0 ;
+            END PINS
+            NETS 0 ;
+            END NETS
+            END DESIGN
+            """
+        ),
+        encoding="utf-8",
+    )
+    _require(ecc_py.def_init(str(design_def)), "def_init")
+    place_db = ecc_py.pydb(ecc_py.get_dmInst(), 2, 2, False, False)  # noqa: FBT003
+    blockages = [
+        [
+            place_db.node_x[node_id],
+            place_db.node_y[node_id],
+            place_db.node_size_x[node_id],
+            place_db.node_size_y[node_id],
+        ]
+        for node_id, name in enumerate(place_db.node_names)
+        if name.startswith("blockage")
+    ]
+    summary = _output(manifest, "pyplacedb_rows.json")
+    summary.write_text(
+        json.dumps(
+            {
+                "blockages": blockages,
+                "num_terminals": place_db.num_terminals,
+                "rows": list(place_db.rows),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return {"summary": summary}
 
 
 def verilog_round_trip(manifest: dict[str, Any]) -> dict[str, Path]:
@@ -275,6 +328,7 @@ SCENARIOS = {
     "floorplan": floorplan,
     "harden": harden,
     "lvs": lvs,
+    "pyplacedb_rows": pyplacedb_rows,
     "rcx": rcx,
     "routing": routing,
     "sta": sta,

--- a/test/support.py
+++ b/test/support.py
@@ -16,6 +16,7 @@ INPUTS = {
     "floorplan": ("floorplan_in.v.gz",),
     "harden": ("harden_in.def.gz", "harden_in.v.gz"),
     "lvs": ("harden_in.def.gz", "harden_in.v.gz"),
+    "pyplacedb_rows": (),
     "rcx": ("route_in.def.gz", "route_in.v.gz"),
     "routing": ("route_in.def.gz",),
     "sta": ("route_in.def.gz", "route_in.v.gz"),


### PR DESCRIPTION
## Summary

- derive unavailable placement area as `core - union(ROW)` during PyPlaceDB import
- merge row-derived obstacles with explicit placement blockages and fixed-instance halos
- subtract real fixed-instance bodies before rectangle decomposition to avoid double counting
- add a subprocess-isolated Python API regression for a cut-row gap

## Motivation

Some DEFs express macro placement halos only by cutting placement rows and contain no explicit `HALO` or placement `BLOCKAGES`. DreamPlace does not consume arbitrary row rectangles during legalization, so those gaps were reconstructed as legal placement area and standard cells could enter the macro halo.

## Verification

- clean GitHub CI passed: `Build Wheel` and `Test Python API`
- Python API suite: `12 passed in 42.87s`, including `test_pyplacedb_converts_missing_row_area_to_fixed_blockage`
- subprocess scenario produces the expected `(4000, 0, 2000, 1400)` blockage while preserving all source rows
- supplied real case imports 770 rows as 8 residual blockage rectangles around the two fixed macros
- isolated Boost geometry benchmark measured about 39-75 us incremental work for 770 rows and 7,342 fixed bodies
- Ruff checks for the new test path and changed additions, clang-format check for the C++ hunk, and `git diff --check` pass
