### PR TITLE
fix(eval): prevent placement map crashes after early-router update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ test/**
 !test/data/test_pyplacedb_rows.py
 !test/operations/
 !test/operations/test_python_operations.py
+!test/operations/test_placement_map.py
 !test/fixtures/
 !test/fixtures/gcd/
 !test/fixtures/gcd/config/

--- a/src/evaluation/src/module/congestion/congestion_eval.cpp
+++ b/src/evaluation/src/module/congestion/congestion_eval.cpp
@@ -736,6 +736,9 @@ float CongestionEval::evalAvgOverflow(string stage, string rt_dir_path, string o
 
   file.close();
 
+  if (values.empty()) {
+    return -1;
+  }
   std::sort(values.begin(), values.end(), std::greater<int32_t>());
 
   size_t size = values.size();

--- a/src/evaluation/src/util/init_egr.cpp
+++ b/src/evaluation/src/util/init_egr.cpp
@@ -71,9 +71,9 @@ void InitEGR::runEGR(bool enable_timing)
   if (_thread_number_override_set && _thread_number_override > 0) {
     config_map.insert({"-thread_number", _thread_number_override});
   }
-  if (_output_inter_result_override_set) {
-    config_map.insert({"-output_inter_result", _output_inter_result_override});
-  }
+  // Evaluation consumes the router's guide and CSV maps, even when the
+  // standalone router defaults to not writing intermediate results.
+  config_map.insert({"-output_inter_result", _output_inter_result_override});
   if (use_timing) {
     config_map.insert({"-enable_timing", 1});
   }

--- a/src/evaluation/src/util/init_egr.h
+++ b/src/evaluation/src/util/init_egr.h
@@ -34,7 +34,7 @@ class InitEGR
   void setTopRoutingLayer(const std::string& layer) { _top_layer_override = layer; }
   void setEnableTimingOverride(bool enable) { _enable_timing_override_set = true; _enable_timing_override = enable; }
   void setThreadNumberOverride(int threads) { _thread_number_override_set = true; _thread_number_override = threads; }
-  void setOutputInterResultOverride(int flag) { _output_inter_result_override_set = true; _output_inter_result_override = flag; }
+  void setOutputInterResultOverride(int flag) { _output_inter_result_override = flag; }
   void setStage(const std::string& stage) { _stage_override = stage; }
   void setResolveCongestion(const std::string& level) { _resolve_congestion_override = level; }
 
@@ -55,7 +55,6 @@ class InitEGR
   bool _enable_timing_override = false;
   bool _thread_number_override_set = false;
   int _thread_number_override = 128;
-  bool _output_inter_result_override_set = false;
   int _output_inter_result_override = 1;
   std::string _stage_override = "egr3D";
   std::string _resolve_congestion_override = "low";

--- a/src/operation/iRT/source/module/early_router/EarlyRouter.cpp
+++ b/src/operation/iRT/source/module/early_router/EarlyRouter.cpp
@@ -2893,6 +2893,7 @@ void EarlyRouter::outputLayerSupplyCSV(ERModel& er_model)
   Monitor monitor;
   RTLOG.info(Loc::current(), "Starting...");
 
+  GridMap<PlanarRect>& gcell_map = RTDM.getDatabase().get_gcell_map();
   std::vector<RoutingLayer>& routing_layer_list = RTDM.getDatabase().get_routing_layer_list();
   std::vector<GridMap<EREdge>>& layer_h_edge_map = er_model.get_layer_h_edge_map();
   std::vector<GridMap<EREdge>>& layer_v_edge_map = er_model.get_layer_v_edge_map();
@@ -2903,9 +2904,11 @@ void EarlyRouter::outputLayerSupplyCSV(ERModel& er_model)
     GridMap<EREdge>& edge_map = routing_layer.isPreferH() ? layer_h_edge_map[layer_idx] : layer_v_edge_map[layer_idx];
     std::ofstream* supply_csv_file
         = RTUTIL.getOutputFileStream(RTUTIL.getString(er_temp_directory_path, "supply_map_", routing_layer.get_layer_name(), ".csv"));
-    for (int32_t y = edge_map.get_y_size() - 1; y >= 0; y--) {
-      for (int32_t x = 0; x < edge_map.get_x_size(); x++) {
-        RTUTIL.pushStream(supply_csv_file, edge_map[x][y].get_supply(), ",");
+    // Keep every layer on the gcell grid so evaluation can combine H/V maps.
+    // Boundary gcells without an outgoing edge contribute zero.
+    for (int32_t y = gcell_map.get_y_size() - 1; y >= 0; y--) {
+      for (int32_t x = 0; x < gcell_map.get_x_size(); x++) {
+        RTUTIL.pushStream(supply_csv_file, edge_map.isInside(x, y) ? edge_map[x][y].get_supply() : 0, ",");
       }
       RTUTIL.pushStream(supply_csv_file, "\n");
     }
@@ -2996,6 +2999,7 @@ void EarlyRouter::outputLayerOverflowCSV(ERModel& er_model)
   Monitor monitor;
   RTLOG.info(Loc::current(), "Starting...");
 
+  GridMap<PlanarRect>& gcell_map = RTDM.getDatabase().get_gcell_map();
   std::vector<RoutingLayer>& routing_layer_list = RTDM.getDatabase().get_routing_layer_list();
   std::vector<GridMap<EREdge>>& layer_h_edge_map = er_model.get_layer_h_edge_map();
   std::vector<GridMap<EREdge>>& layer_v_edge_map = er_model.get_layer_v_edge_map();
@@ -3007,9 +3011,11 @@ void EarlyRouter::outputLayerOverflowCSV(ERModel& er_model)
     std::ofstream* overflow_csv_file
         = RTUTIL.getOutputFileStream(RTUTIL.getString(er_temp_directory_path, "overflow_map_", routing_layer.get_layer_name(), ".csv"));
 
-    for (int32_t y = edge_map.get_y_size() - 1; y >= 0; y--) {
-      for (int32_t x = 0; x < edge_map.get_x_size(); x++) {
-        RTUTIL.pushStream(overflow_csv_file, getReportedOverflow(edge_map, x, y), ",");
+    // Keep every layer on the gcell grid so evaluation can combine H/V maps.
+    // Boundary gcells without an outgoing edge contribute zero.
+    for (int32_t y = gcell_map.get_y_size() - 1; y >= 0; y--) {
+      for (int32_t x = 0; x < gcell_map.get_x_size(); x++) {
+        RTUTIL.pushStream(overflow_csv_file, edge_map.isInside(x, y) ? getReportedOverflow(edge_map, x, y) : 0, ",");
       }
       RTUTIL.pushStream(overflow_csv_file, "\n");
     }

--- a/test/native_scenarios.py
+++ b/test/native_scenarios.py
@@ -52,6 +52,17 @@ def def_round_trip(manifest: dict[str, Any]) -> dict[str, Path]:
     return {"def": output}
 
 
+def placement_map(manifest: dict[str, Any]) -> dict[str, Path]:
+    _setup(manifest)
+    _read_design(manifest)
+    feature_dir = _output(manifest, "feature")
+    _require(ecc_py.db_init(feature_path=str(feature_dir)), "db_init feature_path")
+    output = feature_dir / "placement.json"
+    _require(ecc_py.feature_pl_eval(str(output), 5), "feature_pl_eval")
+    _require_file(output)
+    return {"feature": output}
+
+
 def def_verify(manifest: dict[str, Any]) -> dict[str, Path]:
     _setup(manifest)
     _read_design(manifest)
@@ -328,6 +339,7 @@ SCENARIOS = {
     "floorplan": floorplan,
     "harden": harden,
     "lvs": lvs,
+    "placement_map": placement_map,
     "pyplacedb_rows": pyplacedb_rows,
     "rcx": rcx,
     "routing": routing,

--- a/test/operations/test_placement_map.py
+++ b/test/operations/test_placement_map.py
@@ -1,0 +1,25 @@
+import csv
+import json
+from pathlib import Path
+
+from support import run_scenario
+
+
+def test_placement_map(test_roots):
+    result = run_scenario(test_roots, "placement_map", timeout=480)
+    summary = json.loads(result.output_path("feature").read_text(encoding="utf-8"))
+    maps = {}
+    for direction, filename in summary["Congestion"]["map"]["egr"].items():
+        with Path(filename).open(encoding="utf-8") as stream:
+            maps[direction] = [list(map(int, row)) for row in csv.reader(stream)]
+
+    horizontal, vertical = maps["horizontal"], maps["vertical"]
+    assert horizontal and horizontal[0]
+    assert [len(row) for row in horizontal] == [len(row) for row in vertical]
+    assert maps["union"] == [
+        [h + v for h, v in zip(h_row, v_row, strict=True)]
+        for h_row, v_row in zip(horizontal, vertical, strict=True)
+    ]
+    assert summary["Congestion"]["overflow"]["total"] == {
+        direction: sum(map(sum, matrix)) for direction, matrix in maps.items()
+    }

--- a/test/support.py
+++ b/test/support.py
@@ -16,6 +16,7 @@ INPUTS = {
     "floorplan": ("floorplan_in.v.gz",),
     "harden": ("harden_in.def.gz", "harden_in.v.gz"),
     "lvs": ("harden_in.def.gz", "harden_in.v.gz"),
+    "placement_map": ("cts_in.def.gz",),
     "pyplacedb_rows": (),
     "rcx": ("route_in.def.gz", "route_in.v.gz"),
     "routing": ("route_in.def.gz",),


### PR DESCRIPTION
Placement feature evaluation crashes with SIGSEGV after the early-router update in #197. The evaluation entry point inherits `output_inter_result=0`, so its required guide/CSV files are missing and `evalAvgOverflow` indexes an empty vector. Horizontal and vertical edge maps also have different dimensions, while evaluation combines them as a common GCell matrix.

Enable intermediate output by default for evaluation, retain explicit overrides, reject empty overflow samples using the existing invalid-result sentinel, and export layer supply/overflow maps on a common GCell grid with zero boundary padding. Add a native placement-map scenario that checks nonempty H/V maps, shape agreement, the union matrix, and overflow totals.

Validation: reproduced the SIGSEGV in `CongestionEval::evalAvgOverflow` using the current native build under gdb; rebuilt `ecc_py`; placement-map and row-blockage native regression tests pass. ECC RCX and RTL-to-GDS integration tests both pass in the same pytest process (602.17s). Non-integration verification: 1884 passed, with one environment-dependent PDK test passing separately after clearing local PDK environment variables; 3 skipped and 4 xfailed. ECC Ruff lint/format checks pass.
