### PR TITLE
perf(idb): fix special net n^2 connection

### DIFF
--- a/src/database/data/design/IdbDesign.cpp
+++ b/src/database/data/design/IdbDesign.cpp
@@ -760,6 +760,43 @@ bool IdbDesign::connectPinToSpecialNet(IdbPin* pin, IdbSpecialNet* net)
   return true;
 }
 
+bool IdbDesign::connectPinsToSpecialNet(const std::vector<IdbPin*>& pins, IdbSpecialNet* net)
+{
+  if (net == nullptr || std::find(pins.begin(), pins.end(), nullptr) != pins.end()) {
+    return false;
+  }
+
+  const auto connected_pins = pins;
+  std::vector<IdbPin*> io_pins;
+  std::vector<IdbPin*> instance_pins;
+  std::vector<IdbInstance*> instances;
+  instance_pins.reserve(pins.size());
+  instances.reserve(pins.size());
+  for (auto* pin : pins) {
+    if (pin->is_io_pin()) {
+      io_pins.emplace_back(pin);
+    } else {
+      instance_pins.emplace_back(pin);
+      if (pin->get_instance() != nullptr) {
+        instances.emplace_back(pin->get_instance());
+      }
+    }
+  }
+  if (!net->get_instance_list()->add_instance_refs(instances)) {
+    return false;
+  }
+  net->get_io_pin_list()->add_pin_refs_unique(io_pins);
+  net->get_instance_pin_list()->add_pin_refs_unique(instance_pins);
+  for (auto* pin : connected_pins) {
+    if (pin->get_special_net() != nullptr && pin->get_special_net() != net) {
+      disconnectPinFromSpecialNet(pin);
+    }
+    pin->set_special_net(net);
+    refreshPinNetName(pin);
+  }
+  return true;
+}
+
 IdbSpecialNet* IdbDesign::findSpecialNetForInstancePin(IdbPin* pin) const
 {
   if (pin == nullptr || pin->is_io_pin()) {

--- a/src/database/data/design/IdbDesign.h
+++ b/src/database/data/design/IdbDesign.h
@@ -224,6 +224,7 @@ class IdbDesign
   IdbSpecialNet* createOrFindSpecialNet(const std::string& net_name, IdbConnectType type = IdbConnectType::kNone,
                                         IdbCreatePolicy policy = IdbCreatePolicy::kReturnExisting);
   bool connectPinToSpecialNet(IdbPin* pin, IdbSpecialNet* net);
+  bool connectPinsToSpecialNet(const std::vector<IdbPin*>& pins, IdbSpecialNet* net);
   IdbSpecialNet* findSpecialNetForInstancePin(IdbPin* pin) const;
   int32_t connectInstancePinsToSpecialNet(const std::vector<std::string>& pin_name_list, IdbSpecialNet* net);
   int32_t materializeSpecialNetWildcardPins(IdbSpecialNet* net);

--- a/src/database/data/design/db_design/IdbInstance.cpp
+++ b/src/database/data/design/db_design/IdbInstance.cpp
@@ -32,6 +32,7 @@
 #include "IdbInstance.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 using namespace std;
 namespace idb {
@@ -550,6 +551,40 @@ bool IdbInstanceList::add_instance_ref(IdbInstance* instance)
   }
 
   _instance_list.emplace_back(instance);
+  return true;
+}
+
+bool IdbInstanceList::add_instance_refs(const std::vector<IdbInstance*>& instances)
+{
+  std::unordered_set<IdbInstance*> instance_index;
+  instance_index.reserve(_instance_list.size() + instances.size());
+  instance_index.insert(_instance_list.begin(), _instance_list.end());
+  auto instance_map = _instance_map;
+  instance_map.reserve(_instance_map.size() + instances.size());
+  std::vector<IdbInstance*> new_instances;
+  new_instances.reserve(instances.size());
+  for (auto* instance : instances) {
+    if (instance == nullptr) {
+      return false;
+    }
+    if (instance_index.contains(instance)) {
+      continue;
+    }
+    const auto& name = instance->get_name();
+    if (!name.empty()) {
+      const auto [iter, inserted] = instance_map.emplace(name, instance);
+      if (!inserted) {
+        if (iter->second != instance) {
+          return false;
+        }
+        continue;
+      }
+    }
+    new_instances.emplace_back(instance);
+    instance_index.insert(instance);
+  }
+  _instance_list.insert(_instance_list.end(), new_instances.begin(), new_instances.end());
+  _instance_map.swap(instance_map);
   return true;
 }
 

--- a/src/database/data/design/db_design/IdbInstance.h
+++ b/src/database/data/design/db_design/IdbInstance.h
@@ -247,6 +247,7 @@ class IdbInstanceList
   IdbInstance* add_instance(IdbInstance* instance = nullptr);
   IdbInstance* add_instance(string name);
   bool add_instance_ref(IdbInstance* instance);
+  bool add_instance_refs(const std::vector<IdbInstance*>& instances);
   bool erase_instance_ref(string name);
   bool erase_instance_ref(IdbInstance* instance);
   bool remove_instance(string name);

--- a/src/database/data/design/db_design/IdbPins.cpp
+++ b/src/database/data/design/db_design/IdbPins.cpp
@@ -548,7 +548,7 @@ IdbPin* IdbPins::find_pin(IdbPin* pin)
   }
 
   for (IdbPin* pin_iter : _pin_list) {
-    if (pin_iter->get_pin_name() == pin->get_pin_name() && pin->get_instance() == pin_iter->get_instance()) {
+    if (pin->get_instance() == pin_iter->get_instance() && pin_iter->get_pin_name() == pin->get_pin_name()) {
       return pin_iter;
     }
   }
@@ -706,6 +706,39 @@ IdbPin* IdbPins::add_pin_ref_unique(IdbPin* pin)
   _pin_list.emplace_back(pin);
   update_pin_ref_index(pin);
   return pin;
+}
+
+void IdbPins::add_pin_refs_unique(const std::vector<IdbPin*>& pins)
+{
+  struct PinHash
+  {
+    size_t operator()(IdbPin* pin) const
+    {
+      return std::hash<IdbInstance*>{}(pin->get_instance()) ^ (std::hash<std::string>{}(pin->get_pin_name()) << 1);
+    }
+  };
+  struct PinEqual
+  {
+    bool operator()(IdbPin* first, IdbPin* second) const
+    {
+      return first->get_instance() == second->get_instance() && first->get_pin_name() == second->get_pin_name();
+    }
+  };
+
+  std::unordered_set<IdbPin*, PinHash, PinEqual> pin_index;
+  pin_index.reserve(_pin_list.size() + pins.size());
+  for (auto* pin : _pin_list) {
+    if (pin != nullptr) {
+      pin_index.insert(pin);
+    }
+  }
+  _pin_list.reserve(_pin_list.size() + pins.size());
+  for (auto* pin : pins) {
+    if (pin != nullptr && pin_index.insert(pin).second) {
+      _pin_list.emplace_back(pin);
+      update_pin_ref_index(pin);
+    }
+  }
 }
 
 void IdbPins::update_pin_ref_index(IdbPin* pin)

--- a/src/database/data/design/db_design/IdbPins.h
+++ b/src/database/data/design/db_design/IdbPins.h
@@ -157,6 +157,7 @@ class IdbPins
   IdbPin* add_pin_list(IdbPin* pin = nullptr);
   IdbPin* add_pin_list(string pin_name);
   IdbPin* add_pin_ref_unique(IdbPin* pin);
+  void add_pin_refs_unique(const std::vector<IdbPin*>& pins);
   void reset();
   void init(int32_t size) { _pin_list.reserve(size); }
 

--- a/src/database/manager/builder/def_builder/def_read.cpp
+++ b/src/database/manager/builder/def_builder/def_read.cpp
@@ -1370,6 +1370,8 @@ int32_t DefRead::parse_pdn(defiNet* def_net)
     net->set_original_net_name(def_net->original());
   }
 
+  std::vector<IdbPin*> connected_pins;
+  connected_pins.reserve(def_net->numConnections());
   for (int i = 0; i < def_net->numConnections(); i++) {
     string io_name = def_net->instance(i);
     std::erase(io_name, '\\');
@@ -1385,7 +1387,7 @@ int32_t DefRead::parse_pdn(defiNet* def_net)
       if (pin == nullptr) {
         ECCLOG.warn(ecc::Loc::current(), "Can not find Pin in Pin list ... pin name = ", def_net->pin(i));
       } else {
-        design->connectPinToSpecialNet(pin, net);
+        connected_pins.emplace_back(pin);
       }
     } else {
       IdbInstance* instance = instance_list->find_instance(io_name);
@@ -1396,12 +1398,17 @@ int32_t DefRead::parse_pdn(defiNet* def_net)
         if (pin == nullptr) {
           ECCLOG.warn(ecc::Loc::current(), "Can not find Pin in Pin list ... pin name = ", def_net->pin(i));
         } else {
-          design->connectPinToSpecialNet(pin, net);
+          connected_pins.emplace_back(pin);
         }
       } else {
         ECCLOG.warn(ecc::Loc::current(), "Can not find instance in instance list ... instance name = ", io_name);
       }
     }
+  }
+
+  if (!design->connectPinsToSpecialNet(connected_pins, net)) {
+    ECCLOG.warn(ecc::Loc::current(), "Connect Special Net pins failed ... net name = ", def_net->name());
+    return kDbFail;
   }
 
   if (net->has_wildcard_instance_pins() && std::getenv("IDB_MATERIALIZE_SPECIALNET_WILDCARD_PINS") != nullptr) {


### PR DESCRIPTION
# perf(idb): 批量构建 DEF special net 连接，消除高扇出去重的平方复杂度

## 问题现象

使用 `cx55_mem/salsa20/salsa20.def` 时，DEF 读入会在 `Begin parse Specialnet.` 与 `End parse Specialnet.` 之间出现明显停顿，而后续普通 net 解析很快。

原始实现的 Debug 构建解析两个 special net 需要约 **163.42 秒**，解析 27,067 个普通 net 仅需约 **0.54 秒**。停顿发生在 iDB 建立连接时，尚未进入 iRT 布线。

### Case 规模

| 项目 | 数量 |
| --- | ---: |
| Instances | 29,356 |
| Special nets | 2，分别为 VDD、VSS |
| 每条 special net 的显式连接 | 28,909 |
| Special net 总连接 | 57,818 |
| 普通 nets | 27,067 |
| 普通 net 总连接 | 91,702 |
| 单条普通 net 的最大连接数 | 33 |

VDD、VSS 的显式连接均无重复，且不使用 wildcard。

## 原因分析

### Pin 逐个插入时反复扫描已有连接

停顿期间的三次 GDB 调用栈采样均命中以下路径：

```text
DefRead::parse_pdn
  -> IdbDesign::connectPinToSpecialNet
    -> IdbSpecialNet::add_instance_pin
      -> IdbPins::add_pin_ref_unique
        -> IdbPins::find_pin
```

每插入一个 pin，`find_pin()` 都会遍历已有 pin，按 **instance 指针＋pin 名称**判断重复。对于一条包含 N 个不同连接的 net，累计比较次数为：

```text
0 + 1 + ... + (N - 1) = N × (N - 1) / 2
```

本 case 的两个电源网合计约有 **8.36 亿次**已有 pin 比较。普通 net 的连接虽然更多，但分散在大量小 net 中，按同样方式估算仅约 **29.47 万次**比较。

此外，`get_pin_name()` 按值返回字符串，原始扫描反复构造、比较和销毁临时字符串；这些操作也在调用栈采样中被观察到，进一步放大了 Debug 构建下的耗时。

### Instance 引用也存在逐个扫描

`IdbInstanceList::add_instance_ref()` 会调用 `contains()`。名称 map 未命中时，`contains()` 仍会扫描已有 instance 的 vector，因此向高扇出 net 逐个添加新 instance 引用同样会产生平方复杂度。

### 去重语义不能退化为仅比较 pin 指针

现有规则是 **instance 指针＋pin 名称**，而不是仅比较 `IdbPin*`。不同的 pin 对象可能表示同一个逻辑连接，因此优化必须保留原有语义，不能直接使用 pin 地址去重代替它。

## 本 PR 的实现

采用按 special net 批量建连的方式，一次建立临时索引，消除 pin 和 instance 两处重复扫描，不引入需要长期维护的语义缓存。

```text
DefRead::parse_pdn
  -> 收集显式连接
  -> IdbDesign::connectPinsToSpecialNet
    -> IdbInstanceList::add_instance_refs
    -> IdbPins::add_pin_refs_unique
    -> 更新 pin 的反向引用和网络名称
```

### 1. 批量收集与连接

`parse_pdn()` 保留原有 instance/pin 查找和名称处理逻辑，收集显式连接后统一调用 `connectPinsToSpecialNet()`。批量连接失败时返回 DEF callback 失败状态，不静默忽略失败。

### 2. Pin 语义哈希去重

`IdbPins::add_pin_refs_unique()` 先将已有连接加入临时哈希集合，再依次处理新连接。哈希和相等判断均基于 **instance 指针＋pin 名称**，仅追加首次出现的逻辑连接，保持原有插入顺序。

索引仅在批处理期间使用。后续 pin 改名、改变所属 instance、删除或清空列表时，不存在需要同步的跨调用语义缓存；下次批处理会根据当前对象重新建索引。

### 3. Instance 批量去重与校验

`IdbInstanceList::add_instance_refs()` 以临时指针集合判断成员关系，并校验名称冲突。先在临时名称 map 和新增列表中完成验证，再更新正式容器；遇到空指针或同名不同实例时返回失败，不留下部分引用或名称索引更新。

该方式保留已有实例改名后仍可通过指针识别、无名称实例按指针去重等行为。

### 4. 保持连接一致性

- 分别维护 IO pin、instance pin 和 instance 引用列表。
- 维护 pin 到 special net 的反向引用，并保留普通 net 名称优先级。
- 重新连接时继续解除旧 special net 上的连接。
- 保存待连接 pin 的快照，避免输入 vector 来自旧 net 时，删除旧连接导致遍历失效。
- 保留既有单个连接接口和 wildcard 处理逻辑，不修改 iRT/iDRC。

## 复杂度与适用范围

已有相关引用数为 K、本次待处理连接数为 N 时，批量去重的平均时间复杂度为 **O(K + N)**，临时辅助空间为 **O(K + N)**。首次为新 net 建连时 K 为 0，即平均 **O(N)**。

本次线性化针对 **DEF 显式 special net 的首次批量建连**。原单个连接接口、wildcard 展开和跨网重新连接时源网逐个删除连接的复杂度保持不变，不能据此声称所有连接操作均已线性化。

## 测试与结果

### 耗时对比

| 版本 | Special net 解析 | 普通 net 解析 |
| --- | ---: | ---: |
| 原始实现，前序定位基线 | 163.420806 秒 | 0.544390 秒 |
| 本 PR 批量实现，当前分支复测 | **0.353181 秒** | 0.492831 秒 |

Special net 解析相对原始基线约加速 **460 倍**，普通 net 解析仍约为 0.5 秒。
