### PR TITLE
fix(iemir): align IR/EM analysis with shared power and resistor inputs

### DIFF
--- a/src/interface/tcl/tcl_iemir/src/tcl_init_emir.cpp
+++ b/src/interface/tcl/tcl_iemir/src/tcl_init_emir.cpp
@@ -26,8 +26,18 @@ TclInitEMIR::TclInitEMIR(const char* cmd_name) : TclCmd(cmd_name)
 {
   // std::string temp_directory_path;       // required
   _config_list.push_back(std::make_pair("-temp_directory_path", ValueType::kString));
-  // std::string instance_power_file_path;  // required
-  _config_list.push_back(std::make_pair("-instance_power_file_path", ValueType::kString));
+  // std::string ptpx_instance_power_file_path;  // required
+  _config_list.push_back(std::make_pair("-ptpx_instance_power_file_path", ValueType::kString));
+  // std::string redhawk_res_network_file_path;  // optional
+  _config_list.push_back(std::make_pair("-redhawk_res_network_file_path", ValueType::kString));
+  // std::string ploc_file_path;            // optional
+  _config_list.push_back(std::make_pair("-ploc_file_path", ValueType::kString));
+  // std::string redhawk_tech_file_path;    // optional
+  _config_list.push_back(std::make_pair("-redhawk_tech_file_path", ValueType::kString));
+  // std::string em_limit_file_path;        // optional
+  _config_list.push_back(std::make_pair("-em_limit_file_path", ValueType::kString));
+  // double em_violation_threshold_percent; // optional
+  _config_list.push_back(std::make_pair("-em_violation_threshold_percent", ValueType::kDouble));
   // int32_t thread_number;                  // optional
   _config_list.push_back(std::make_pair("-thread_number", ValueType::kInt));
 

--- a/src/operation/iEMIR/README.md
+++ b/src/operation/iEMIR/README.md
@@ -1,0 +1,65 @@
+# iEMIR static IR/EM inputs
+
+iEMIR reads the loaded LEF/DEF database into its own power network, imports
+instance power, builds and solves the network, and writes IR/EM reports. It does
+not run iSTA or write its solved network back into the shared design database.
+
+## Tcl interface
+
+Load technology LEF, cell LEF and the design DEF before `init_emir`. The current
+comparison driver also loads Liberty. For the shared resistor comparison flow:
+
+```tcl
+init_emir \
+  -temp_directory_path ./emir_output \
+  -ptpx_instance_power_file_path ./design.ptpx.tsv \
+  -redhawk_res_network_file_path ./design.res_network \
+  -ploc_file_path ./design.ploc \
+  -redhawk_tech_file_path ./process.tech \
+  -em_violation_threshold_percent 100.0 \
+  -thread_number 4
+run_emir
+destroy_emir
+```
+
+| Input | Contract |
+| --- | --- |
+| `-ptpx_instance_power_file_path` | Required. TSV with the `# iEMIR_PTPX_INSTANCE_POWER_V1` marker and the seven columns below. |
+| `-redhawk_res_network_file_path` | Imports wire/via resistances and connection metadata. The comparison driver requires this input. If omitted, the native LEF/DEF geometry path constructs resistances; that is a different extraction model. |
+| `-ploc_file_path` | Explicit supply contacts. Without a PLOC file, the graph must have connected DEF PG IO sources. A graph without a source fails; top-layer nodes are never automatically made ideal sources. |
+| `-redhawk_tech_file_path` | EM technology rules. |
+| `-em_limit_file_path` | Optional rule overrides. EM assessment needs applicable rules; missing rules are not evidence of passing EM. |
+| `-em_violation_threshold_percent` | Report threshold; defaults to 100.0. |
+| `-temp_directory_path` | Per-run output directory, recreated during initialization. Use a separate directory for each run. |
+| `-thread_number` | OpenMP thread count. |
+
+The power TSV header is:
+
+```text
+instance_name	voltage_v	internal_power_w	switching_power_w	leakage_power_w	total_power_w	average_current_a
+```
+
+Fields use volts, watts and amperes. The reader checks component sums and
+`voltage_v * average_current_a == total_power_w` within its numerical tolerance;
+instance names are mapped to DEF instances. This is the normalized PTPX export,
+not a raw commercial report or an iSTA binary power file.
+
+Golden `.ir.full` and `.em.worst` files belong to the external comparison step;
+iEMIR does not read them to solve voltages or currents. Its own reports are
+written under `emir_reporter/`, with solver diagnostics under `ir_analyzer/`.
+
+## Module boundary
+
+The public interface owns file import. Graph construction uses `PowerNet` data
+and its explicit-parasitic flag, without consulting the input filename. Imported
+pin loads retain area-based distribution, and via reporting retains the original
+physical location separately from its electrical endpoints.
+
+The supported interface has no `-instance_power_file_path` alias, PG SPEF import
+option or generated-source compatibility switch. It does not require a power
+SPEF in the shared SPEF reader. iSTA activity configuration is outside this
+module's change set.
+
+PLOC/DEF supply-location background: `RedHawk_User_Manual_11.1.pdf`, PDF
+pp. 604–605. The interface and module-boundary decisions above describe this
+implementation; they are not requirements imposed by that manual.

--- a/src/operation/iEMIR/interface/EMIRInterface.cpp
+++ b/src/operation/iEMIR/interface/EMIRInterface.cpp
@@ -28,10 +28,37 @@
 #include "PowerPin.hpp"
 #include "PowerVia.hpp"
 #include "PowerWireSegment.hpp"
+#include "RedHawkResNetworkReader.hpp"
 #include "Utility.hpp"
 #include "idm.h"
 
 namespace iemir {
+
+namespace {
+
+int32_t micronToDBU(double value, int32_t micron_dbu)
+{
+  return static_cast<int32_t>(std::llround(value * micron_dbu));
+}
+
+std::pair<idb::IdbLayer*, idb::IdbLayer*> getAdjacentRoutingLayers(idb::IdbLayers* layers, idb::IdbLayer* cut_layer)
+{
+  idb::IdbLayer* bottom_layer = nullptr;
+  idb::IdbLayer* top_layer = nullptr;
+  for (idb::IdbLayer* routing_layer : layers->get_routing_layers()) {
+    if (routing_layer->get_order() < cut_layer->get_order()
+        && (bottom_layer == nullptr || routing_layer->get_order() > bottom_layer->get_order())) {
+      bottom_layer = routing_layer;
+    }
+    if (routing_layer->get_order() > cut_layer->get_order()
+        && (top_layer == nullptr || routing_layer->get_order() < top_layer->get_order())) {
+      top_layer = routing_layer;
+    }
+  }
+  return {bottom_layer, top_layer};
+}
+
+}  // namespace
 
 EMIRInterface* EMIRInterface::_emir_interface_instance = nullptr;
 
@@ -149,7 +176,15 @@ void EMIRInterface::wrapConfig(std::map<std::string, std::any>& config_map)
 {
   /////////////////////////////////////////////
   EMIRDM.getConfig().temp_directory_path = EMIRUTIL.getConfigValue<std::string>(config_map, "-temp_directory_path", "./emir_temp_directory");
-  EMIRDM.getConfig().instance_power_file_path = EMIRUTIL.getConfigValue<std::string>(config_map, "-instance_power_file_path", "");
+  EMIRDM.getConfig().ptpx_instance_power_file_path
+      = EMIRUTIL.getConfigValue<std::string>(config_map, "-ptpx_instance_power_file_path", "");
+  EMIRDM.getConfig().redhawk_res_network_file_path
+      = EMIRUTIL.getConfigValue<std::string>(config_map, "-redhawk_res_network_file_path", "");
+  EMIRDM.getConfig().ploc_file_path = EMIRUTIL.getConfigValue<std::string>(config_map, "-ploc_file_path", "");
+  EMIRDM.getConfig().redhawk_tech_file_path = EMIRUTIL.getConfigValue<std::string>(config_map, "-redhawk_tech_file_path", "");
+  EMIRDM.getConfig().em_limit_file_path = EMIRUTIL.getConfigValue<std::string>(config_map, "-em_limit_file_path", "");
+  EMIRDM.getConfig().em_violation_threshold_percent
+      = EMIRUTIL.getConfigValue<double>(config_map, "-em_violation_threshold_percent", 100.0);
   EMIRDM.getConfig().thread_number = EMIRUTIL.getConfigValue<int32_t>(config_map, "-thread_number", 128);
   omp_set_num_threads(std::max(EMIRDM.getConfig().thread_number, 1));
   /////////////////////////////////////////////
@@ -160,6 +195,9 @@ void EMIRInterface::wrapDatabase()
   wrapDBInfo();
   wrapInstanceIdSet();
   wrapPowerNetList();
+  if (!EMIRDM.getConfig().redhawk_res_network_file_path.empty()) {
+    wrapRedHawkResNetwork();
+  }
 }
 
 void EMIRInterface::wrapDBInfo()
@@ -172,10 +210,13 @@ void EMIRInterface::wrapDBInfo()
 void EMIRInterface::wrapInstanceIdSet()
 {
   std::set<uint64_t>& instance_id_set = EMIRDM.getDatabase().get_instance_id_set();
+  std::map<std::string, uint64_t>& instance_name_to_id_map = EMIRDM.getDatabase().get_instance_name_to_id_map();
   instance_id_set.clear();
+  instance_name_to_id_map.clear();
   idb::IdbDesign* idb_design = dmInst->get_idb_design();
   for (idb::IdbInstance* idb_instance : idb_design->get_instance_list()->get_instance_list()) {
     instance_id_set.insert(idb_instance->get_id());
+    instance_name_to_id_map[idb_instance->get_name()] = idb_instance->get_id();
   }
 }
 
@@ -191,6 +232,110 @@ void EMIRInterface::wrapPowerNetList()
     }
     wrapPowerNet(idb_power_net);
   }
+}
+
+void EMIRInterface::wrapRedHawkResNetwork()
+{
+  RedHawkResNetwork network = RedHawkResNetworkReader::read(EMIRDM.getConfig().redhawk_res_network_file_path);
+  idb::IdbLayers* layers = dmInst->get_idb_layout()->get_layers();
+  int32_t micron_dbu = EMIRDM.getDatabase().get_micron_dbu();
+  std::unordered_map<std::string, std::vector<PowerWireSegment>> wire_lists;
+  std::unordered_map<std::string, std::vector<PowerVia>> via_lists;
+  std::unordered_map<std::string, const RedHawkWireSegmentRecord*> wire_segment_map;
+
+  for (const RedHawkWireSegmentRecord& record : network.wire_segments) {
+    wire_segment_map[record.id] = &record;
+    idb::IdbLayer* layer = layers->find_layer(record.layer_name);
+    if (layer == nullptr || !layer->is_routing()) {
+      EMIRLOG.error(Loc::current(), "RedHawk res_network uses an unmapped routing layer: ", record.layer_name);
+    }
+    PowerWireSegment wire;
+    wire.set_layer_idx(layer->get_id());
+    wire.set_layer_name(layer->get_name());
+    wire.set_first_x(micronToDBU(record.first_x_um, micron_dbu));
+    wire.set_first_y(micronToDBU(record.first_y_um, micron_dbu));
+    wire.set_second_x(micronToDBU(record.second_x_um, micron_dbu));
+    wire.set_second_y(micronToDBU(record.second_y_um, micron_dbu));
+    wire.set_width(std::max(micronToDBU(record.width_um, micron_dbu), 1));
+    wire.set_resistance(record.resistance_ohm);
+    wire_lists[record.net_name].push_back(std::move(wire));
+  }
+
+  for (const RedHawkViaRecord& record : network.vias) {
+    idb::IdbLayer* cut_layer = layers->find_layer(record.layer_name);
+    if (cut_layer == nullptr || !cut_layer->is_cut()) {
+      EMIRLOG.error(Loc::current(), "RedHawk res_network uses an unmapped cut layer: ", record.layer_name);
+    }
+    auto [bottom_layer, top_layer] = getAdjacentRoutingLayers(layers, cut_layer);
+    if (bottom_layer == nullptr || top_layer == nullptr) {
+      EMIRLOG.error(Loc::current(), "Cannot map adjacent routing layers for RedHawk cut layer: ", record.layer_name);
+    }
+
+    PowerVia via;
+    via.set_via_name(record.via_name);
+    via.set_bottom_layer_name(bottom_layer->get_name());
+    via.set_top_layer_name(top_layer->get_name());
+    via.set_bottom_layer_idx(bottom_layer->get_id());
+    via.set_top_layer_idx(top_layer->get_id());
+    via.set_x(micronToDBU(record.x_um, micron_dbu));
+    via.set_y(micronToDBU(record.y_um, micron_dbu));
+    std::optional<std::pair<double, double>> bottom_coordinate
+        = RedHawkResNetworkReader::connectionCoordinate(record, wire_segment_map, bottom_layer->get_name());
+    std::optional<std::pair<double, double>> top_coordinate = RedHawkResNetworkReader::connectionCoordinate(record, wire_segment_map, top_layer->get_name());
+    if (bottom_coordinate.has_value()) {
+      via.set_bottom_x(micronToDBU(bottom_coordinate->first, micron_dbu));
+      via.set_bottom_y(micronToDBU(bottom_coordinate->second, micron_dbu));
+    }
+    if (top_coordinate.has_value()) {
+      via.set_top_x(micronToDBU(top_coordinate->first, micron_dbu));
+      via.set_top_y(micronToDBU(top_coordinate->second, micron_dbu));
+    }
+    via.set_cut_num(record.cut_num);
+    via.set_cut_area_um2(static_cast<double>(record.cut_num) * record.cut_width_um * record.cut_height_um);
+    int32_t half_cut_width = std::max(micronToDBU(record.cut_width_um / 2.0, micron_dbu), 1);
+    int32_t half_cut_height = std::max(micronToDBU(record.cut_height_um / 2.0, micron_dbu), 1);
+    via.set_cut_low_x(-half_cut_width);
+    via.set_cut_low_y(-half_cut_height);
+    via.set_cut_high_x(half_cut_width);
+    via.set_cut_high_y(half_cut_height);
+    via.set_resistance(record.resistance_ohm);
+    via_lists[record.net_name].push_back(std::move(via));
+  }
+
+  std::map<std::string, PowerNet>& power_net_map = EMIRDM.getDatabase().get_power_net_map();
+  for (const auto& [net_name, wires] : wire_lists) {
+    if (power_net_map.count(net_name) == 0) {
+      EMIRLOG.error(Loc::current(), "RedHawk res_network net is not a DEF POWER/GROUND net: ", net_name);
+    }
+  }
+  for (const auto& [net_name, vias] : via_lists) {
+    if (power_net_map.count(net_name) == 0) {
+      EMIRLOG.error(Loc::current(), "RedHawk res_network net is not a DEF POWER/GROUND net: ", net_name);
+    }
+  }
+
+  std::size_t imported_net_num = 0;
+  for (auto& [net_name, power_net] : power_net_map) {
+    auto wire_iter = wire_lists.find(net_name);
+    if (wire_iter == wire_lists.end()) {
+      continue;
+    }
+    power_net.get_wire_segment_list() = std::move(wire_iter->second);
+    auto via_iter = via_lists.find(net_name);
+    if (via_iter == via_lists.end()) {
+      power_net.get_via_list().clear();
+    } else {
+      power_net.get_via_list() = std::move(via_iter->second);
+    }
+    power_net.set_has_explicit_parasitics(true);
+    imported_net_num++;
+  }
+  if (imported_net_num == 0) {
+    EMIRLOG.error(Loc::current(), "The RedHawk res_network contains no DEF POWER/GROUND net: ",
+                  EMIRDM.getConfig().redhawk_res_network_file_path);
+  }
+  EMIRLOG.info(Loc::current(), "Imported ", network.wire_segments.size(), " RedHawk PG wire resistors and ", network.vias.size(),
+               " via resistors from ", imported_net_num, " nets in ", EMIRDM.getConfig().redhawk_res_network_file_path);
 }
 
 void EMIRInterface::wrapPowerNet(idb::IdbSpecialNet* idb_power_net)
@@ -262,11 +407,33 @@ void EMIRInterface::wrapPowerVia(PowerNet& power_net, idb::IdbVia* idb_via)
   idb::IdbCoordinate<int32_t>* coordinate = idb_via->get_coordinate();
   idb::IdbViaMaster* idb_via_master = idb_via->get_instance();
   PowerVia power_via;
+  std::string via_name = idb_via->get_name();
+  if (via_name.empty() && idb_via_master != nullptr) {
+    via_name = idb_via_master->get_name();
+  }
+  power_via.set_via_name(via_name);
+  power_via.set_bottom_layer_name(bottom_layer_shape.get_layer()->get_name());
+  power_via.set_top_layer_name(top_layer_shape.get_layer()->get_name());
   power_via.set_bottom_layer_idx(bottom_layer_shape.get_layer()->get_id());
   power_via.set_top_layer_idx(top_layer_shape.get_layer()->get_id());
   power_via.set_x(coordinate->get_x());
   power_via.set_y(coordinate->get_y());
   power_via.set_cut_num(static_cast<int32_t>(cut_layer_shape.get_rect_list().size()));
+  int32_t micron_dbu = EMIRDM.getDatabase().get_micron_dbu();
+  double cut_area_um2 = 0.0;
+  for (idb::IdbRect* cut_rect : cut_layer_shape.get_rect_list()) {
+    if (cut_rect == nullptr || micron_dbu <= 0) {
+      continue;
+    }
+    cut_area_um2 += static_cast<double>(cut_rect->get_width()) * static_cast<double>(cut_rect->get_height())
+                    / static_cast<double>(micron_dbu) / static_cast<double>(micron_dbu);
+  }
+  power_via.set_cut_area_um2(cut_area_um2);
+  idb::IdbRect cut_bounding_box = idb_via->get_cut_bounding_box();
+  power_via.set_cut_low_x(cut_bounding_box.get_low_x() - coordinate->get_x());
+  power_via.set_cut_low_y(cut_bounding_box.get_low_y() - coordinate->get_y());
+  power_via.set_cut_high_x(cut_bounding_box.get_high_x() - coordinate->get_x());
+  power_via.set_cut_high_y(cut_bounding_box.get_high_y() - coordinate->get_y());
   if (idb_via_master->get_resistance() > 0.0) {
     power_via.set_resistance(idb_via_master->get_resistance());
   } else if (idb_via_master->get_master_generate()->get_rule_generate() != nullptr
@@ -311,11 +478,30 @@ double EMIRInterface::getGeneratedViaResistance(idb::IdbViaMaster* idb_via_maste
 
 void EMIRInterface::wrapPowerPinList(PowerNet& power_net, idb::IdbSpecialNet* idb_power_net)
 {
+  std::unordered_set<idb::IdbPin*> wrapped_pins;
   for (idb::IdbPin* idb_pin : idb_power_net->get_instance_pin_list()->get_pin_list()) {
-    wrapPowerPin(power_net, idb_pin, false);
+    if (idb_pin != nullptr && wrapped_pins.insert(idb_pin).second) {
+      wrapPowerPin(power_net, idb_pin, false);
+    }
+  }
+  idb::IdbDesign* idb_design = dmInst->get_idb_design();
+  if (idb_power_net->has_wildcard_instance_pins()) {
+    for (idb::IdbInstance* idb_instance : idb_design->get_instance_list()->get_instance_list()) {
+      if (idb_instance == nullptr || idb_instance->get_pin_list() == nullptr) {
+        continue;
+      }
+      for (idb::IdbPin* idb_pin : idb_instance->get_pin_list()->get_pin_list()) {
+        if (idb_pin != nullptr && idb_design->findSpecialNetForInstancePin(idb_pin) == idb_power_net
+            && wrapped_pins.insert(idb_pin).second) {
+          wrapPowerPin(power_net, idb_pin, false);
+        }
+      }
+    }
   }
   for (idb::IdbPin* idb_pin : idb_power_net->get_io_pin_list()->get_pin_list()) {
-    wrapPowerPin(power_net, idb_pin, true);
+    if (idb_pin != nullptr && wrapped_pins.insert(idb_pin).second) {
+      wrapPowerPin(power_net, idb_pin, true);
+    }
   }
 }
 
@@ -339,6 +525,10 @@ void EMIRInterface::wrapPowerPinShape(PowerNet& power_net, idb::IdbPin* idb_pin,
   power_pin.set_layer_idx(idb_layer_shape->get_layer()->get_id());
   power_pin.set_x((idb_bounding_box.get_low_x() + idb_bounding_box.get_high_x()) / 2);
   power_pin.set_y((idb_bounding_box.get_low_y() + idb_bounding_box.get_high_y()) / 2);
+  power_pin.set_low_x(idb_bounding_box.get_low_x());
+  power_pin.set_low_y(idb_bounding_box.get_low_y());
+  power_pin.set_high_x(idb_bounding_box.get_high_x());
+  power_pin.set_high_y(idb_bounding_box.get_high_y());
   power_pin.set_is_source(is_source);
   power_net.get_pin_list().push_back(power_pin);
 }

--- a/src/operation/iEMIR/interface/EMIRInterface.hpp
+++ b/src/operation/iEMIR/interface/EMIRInterface.hpp
@@ -71,6 +71,7 @@ class EMIRInterface
   void wrapDBInfo();
   void wrapInstanceIdSet();
   void wrapPowerNetList();
+  void wrapRedHawkResNetwork();
   void wrapPowerNet(idb::IdbSpecialNet* idb_power_net);
   PowerNetType wrapPowerNetType(idb::IdbConnectType connect_type);
   void wrapPowerWireSegmentList(PowerNet& power_net, idb::IdbSpecialNet* idb_power_net);

--- a/src/operation/iEMIR/source/data_manager/CMakeLists.txt
+++ b/src/operation/iEMIR/source/data_manager/CMakeLists.txt
@@ -8,6 +8,8 @@ endif()
 
 add_library(iemir_data_manager
     ${IEMIR_DATA_MANAGER}/DataManager.cpp
+    ${IEMIR_DATA_MANAGER}/PTPXPowerReader.cpp
+    ${IEMIR_DATA_MANAGER}/RedHawkResNetworkReader.cpp
 )
 
 target_link_libraries(iemir_data_manager

--- a/src/operation/iEMIR/source/data_manager/DataManager.cpp
+++ b/src/operation/iEMIR/source/data_manager/DataManager.cpp
@@ -16,10 +16,147 @@
 // ***************************************************************************************
 #include "DataManager.hpp"
 
+#include "EMTech.hpp"
 #include "EMIRInterface.hpp"
 #include "Logger.hpp"
 #include "Monitor.hpp"
+#include "PTPXPowerReader.hpp"
 #include "Utility.hpp"
+
+namespace {
+
+std::string trim(const std::string& text)
+{
+  std::size_t begin = 0;
+  while (begin < text.size() && std::isspace(static_cast<unsigned char>(text[begin]))) {
+    begin++;
+  }
+  std::size_t end = text.size();
+  while (end > begin && std::isspace(static_cast<unsigned char>(text[end - 1]))) {
+    end--;
+  }
+  return text.substr(begin, end - begin);
+}
+
+std::string toUpper(std::string text)
+{
+  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+  return text;
+}
+
+std::string normalizeRuleName(const std::string& name)
+{
+  std::string result;
+  for (char ch : name) {
+    if (std::isalnum(static_cast<unsigned char>(ch)) || ch == '_') {
+      result.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));
+    }
+  }
+  return result;
+}
+
+std::vector<std::string> getRuleAliases(const std::string& name)
+{
+  std::vector<std::string> aliases;
+  std::string normalized_name = normalizeRuleName(name);
+  if (normalized_name.empty()) {
+    return aliases;
+  }
+  aliases.push_back(normalized_name);
+  std::smatch match;
+  if (std::regex_match(normalized_name, match, std::regex("^M([0-9]+)$"))) {
+    aliases.push_back("MET" + match.str(1));
+  } else if (std::regex_match(normalized_name, match, std::regex("^MET([0-9]+)$"))) {
+    aliases.push_back("M" + match.str(1));
+  } else if (std::regex_match(normalized_name, match, std::regex("^V([0-9]+)$"))) {
+    aliases.push_back("VIA" + match.str(1));
+  } else if (std::regex_match(normalized_name, match, std::regex("^VIA([0-9]+)$"))) {
+    aliases.push_back("V" + match.str(1));
+  } else if (normalized_name == "TM") {
+    aliases.push_back("T4M2");
+  } else if (normalized_name == "T4M2") {
+    aliases.push_back("TM");
+  } else if (normalized_name == "TV") {
+    aliases.push_back("T4V2");
+  } else if (normalized_name == "T4V2") {
+    aliases.push_back("TV");
+  }
+  std::sort(aliases.begin(), aliases.end());
+  aliases.erase(std::unique(aliases.begin(), aliases.end()), aliases.end());
+  return aliases;
+}
+
+bool parseDouble(const std::string& text, double& value)
+{
+  char* end = nullptr;
+  value = std::strtod(text.c_str(), &end);
+  return end != text.c_str();
+}
+
+void addMetalRule(iemir::EMTech& em_tech, const std::string& name, double em_limit_ma_per_um, double em_adjust_um)
+{
+  if (name.empty() || em_limit_ma_per_um <= 0.0) {
+    return;
+  }
+  for (const std::string& alias : getRuleAliases(name)) {
+    iemir::EMMetalRule rule;
+    rule.set_name(alias);
+    rule.set_em_limit_ma_per_um(em_limit_ma_per_um);
+    rule.set_em_adjust_um(em_adjust_um);
+    em_tech.get_metal_rule_map()[alias] = rule;
+  }
+}
+
+void addViaRule(iemir::EMTech& em_tech, const std::string& name, double em_limit_ma, double reference_area_um2)
+{
+  if (name.empty() || em_limit_ma <= 0.0) {
+    return;
+  }
+  for (const std::string& alias : getRuleAliases(name)) {
+    iemir::EMViaRule rule;
+    rule.set_name(alias);
+    rule.set_em_limit_ma(em_limit_ma);
+    rule.set_reference_area_um2(reference_area_um2);
+    em_tech.get_via_rule_map()[alias] = rule;
+  }
+}
+
+std::vector<std::string> tokenizeRedHawkTechFile(const std::string& file_path)
+{
+  std::ifstream input(file_path);
+  std::vector<std::string> tokens;
+  std::string token;
+  std::string line;
+  while (std::getline(input, line)) {
+    std::size_t comment_pos = line.find('#');
+    if (comment_pos != std::string::npos) {
+      line = line.substr(0, comment_pos);
+    }
+    for (char ch : line) {
+      if (ch == '{' || ch == '}') {
+        if (!token.empty()) {
+          tokens.push_back(token);
+          token.clear();
+        }
+        tokens.emplace_back(1, ch);
+      } else if (std::isspace(static_cast<unsigned char>(ch))) {
+        if (!token.empty()) {
+          tokens.push_back(token);
+          token.clear();
+        }
+      } else {
+        token.push_back(ch);
+      }
+    }
+    if (!token.empty()) {
+      tokens.push_back(token);
+      token.clear();
+    }
+  }
+  return tokens;
+}
+
+}  // namespace
 
 namespace iemir {
 
@@ -84,6 +221,21 @@ void DataManager::buildConfig()
   // **********       EMIR        ********** //
   _config.temp_directory_path = std::filesystem::absolute(_config.temp_directory_path);
   _config.temp_directory_path += "/";
+  if (!_config.redhawk_tech_file_path.empty()) {
+    _config.redhawk_tech_file_path = std::filesystem::absolute(_config.redhawk_tech_file_path);
+  }
+  if (!_config.ptpx_instance_power_file_path.empty()) {
+    _config.ptpx_instance_power_file_path = std::filesystem::absolute(_config.ptpx_instance_power_file_path);
+  }
+  if (!_config.ploc_file_path.empty()) {
+    _config.ploc_file_path = std::filesystem::absolute(_config.ploc_file_path);
+  }
+  if (!_config.redhawk_res_network_file_path.empty()) {
+    _config.redhawk_res_network_file_path = std::filesystem::absolute(_config.redhawk_res_network_file_path);
+  }
+  if (!_config.em_limit_file_path.empty()) {
+    _config.em_limit_file_path = std::filesystem::absolute(_config.em_limit_file_path);
+  }
   _config.log_file_path = _config.temp_directory_path + "emir.log";
   // **********    DataManager    ********** //
   _config.dm_temp_directory_path = _config.temp_directory_path + "data_manager/";
@@ -117,91 +269,233 @@ void DataManager::buildConfig()
 void DataManager::buildDatabase()
 {
   readInstancePower();
+  readPowerSourceFile();
+  readEMTech();
+}
+
+void DataManager::readPowerSourceFile()
+{
+  std::vector<PowerSource>& source_list = _database.get_power_source_list();
+  source_list.clear();
+  if (_config.ploc_file_path.empty()) {
+    return;
+  }
+  if (!std::filesystem::is_regular_file(_config.ploc_file_path)) {
+    EMIRLOG.error(Loc::current(), "The PLOC file is missing: ", _config.ploc_file_path);
+  }
+  std::ifstream input(_config.ploc_file_path);
+  std::string line;
+  std::size_t line_number = 0;
+  while (std::getline(input, line)) {
+    line_number++;
+    std::size_t comment_pos = line.find('#');
+    if (comment_pos != std::string::npos) {
+      line = line.substr(0, comment_pos);
+    }
+    line = trim(line);
+    if (line.empty()) {
+      continue;
+    }
+    std::string name;
+    std::string layer_name;
+    std::string type_name;
+    double x_um = 0.0;
+    double y_um = 0.0;
+    std::istringstream iss(line);
+    if (!(iss >> name >> x_um >> y_um >> layer_name >> type_name)) {
+      EMIRLOG.error(Loc::current(), "Invalid PLOC record at line ", line_number, ": ", line);
+    }
+    type_name = toUpper(type_name);
+    PowerNetType net_type = type_name == "POWER" ? PowerNetType::kPower
+                                                 : (type_name == "GROUND" ? PowerNetType::kGround : PowerNetType::kNone);
+    if (net_type == PowerNetType::kNone) {
+      EMIRLOG.error(Loc::current(), "Invalid PLOC source type at line ", line_number, ": ", type_name);
+    }
+    std::string marker = net_type == PowerNetType::kPower ? "_POWER_" : "_GROUND_";
+    std::size_t marker_pos = name.rfind(marker);
+    PowerSource source;
+    source.set_name(name);
+    source.set_net_name(marker_pos == std::string::npos ? "" : name.substr(0, marker_pos));
+    source.set_layer_name(layer_name);
+    source.set_net_type(net_type);
+    source.set_x(static_cast<int32_t>(std::llround(x_um * _database.get_micron_dbu())));
+    source.set_y(static_cast<int32_t>(std::llround(y_um * _database.get_micron_dbu())));
+    source_list.push_back(source);
+  }
+  if (source_list.empty()) {
+    EMIRLOG.error(Loc::current(), "The PLOC file does not contain any source: ", _config.ploc_file_path);
+  }
+  EMIRLOG.info(Loc::current(), "Loaded ", source_list.size(), " source locations from ", _config.ploc_file_path);
 }
 
 void DataManager::readInstancePower()
 {
-  if (_config.instance_power_file_path.empty()) {
-    EMIRLOG.error(Loc::current(), "The instance_power_file_path is empty!");
+  if (_config.ptpx_instance_power_file_path.empty()) {
+    EMIRLOG.error(Loc::current(), "ptpx_instance_power_file_path is required!");
+  }
+  std::vector<PTPXPowerRecord> records;
+  try {
+    records = PTPXPowerReader::read(_config.ptpx_instance_power_file_path);
+  } catch (const std::exception& error) {
+    EMIRLOG.error(Loc::current(), error.what());
   }
 
-  std::ifstream* instance_power_file = EMIRUTIL.getInputFileStream(_config.instance_power_file_path);
-  uint64_t instance_power_num = 0;
-  readInstancePowerHeader(instance_power_file, instance_power_num);
-
-  if (instance_power_num > (std::numeric_limits<uint64_t>::max() - 24) / 44) {
-    EMIRLOG.error(Loc::current(), "The instance power file record count is invalid!");
+  std::map<uint64_t, InstancePower>& instance_power_map = _database.get_instance_power_map();
+  std::map<std::string, uint64_t>& instance_name_to_id_map = _database.get_instance_name_to_id_map();
+  instance_power_map.clear();
+  std::size_t unknown_record_num = 0;
+  double report_total_power = 0.0;
+  double matched_total_power = 0.0;
+  for (const PTPXPowerRecord& record : records) {
+    report_total_power += record.total_power;
+    auto instance_iter = instance_name_to_id_map.find(record.instance_name);
+    if (instance_iter == instance_name_to_id_map.end() && !record.instance_name.empty() && record.instance_name.front() == '\\') {
+      instance_iter = instance_name_to_id_map.find(record.instance_name.substr(1));
+    }
+    if (instance_iter == instance_name_to_id_map.end()) {
+      unknown_record_num++;
+      continue;
+    }
+    InstancePower instance_power;
+    instance_power.set_instance_id(instance_iter->second);
+    instance_power.set_voltage(record.voltage);
+    instance_power.set_internal_power(record.internal_power);
+    instance_power.set_switching_power(record.switching_power);
+    instance_power.set_leakage_power(record.leakage_power);
+    instance_power.set_average_current(record.average_current);
+    instance_power_map[instance_iter->second] = std::move(instance_power);
+    matched_total_power += record.total_power;
   }
-  instance_power_file->seekg(0, std::ios::end);
-  std::streamoff file_size = instance_power_file->tellg();
-  std::streamoff expected_file_size = static_cast<std::streamoff>(24 + instance_power_num * 44);
-  if (file_size != expected_file_size) {
-    EMIRLOG.error(Loc::current(), "The instance power file length is inconsistent!");
+  if (instance_power_map.empty() || report_total_power <= 0.0 || matched_total_power <= 0.0) {
+    EMIRLOG.error(Loc::current(), "No non-zero PT-PX instance power matched the DEF design.");
   }
-  instance_power_file->seekg(24, std::ios::beg);
-
-  _database.get_instance_power_map().clear();
-  for (uint64_t instance_power_idx = 0; instance_power_idx < instance_power_num; instance_power_idx++) {
-    readInstancePowerRecord(instance_power_file);
-  }
-  EMIRUTIL.closeFileStream(instance_power_file);
-}
-
-void DataManager::readInstancePowerHeader(std::ifstream* instance_power_file, uint64_t& instance_power_num)
-{
-  char magic[8];
-  uint32_t version = 0;
-  uint32_t record_size = 0;
-  instance_power_file->read(magic, static_cast<std::streamsize>(sizeof(magic)));
-  instance_power_file->read(reinterpret_cast<char*>(&version), static_cast<std::streamsize>(sizeof(version)));
-  instance_power_file->read(reinterpret_cast<char*>(&record_size), static_cast<std::streamsize>(sizeof(record_size)));
-  instance_power_file->read(reinterpret_cast<char*>(&instance_power_num), static_cast<std::streamsize>(sizeof(instance_power_num)));
-  if (!(*instance_power_file)) {
-    EMIRLOG.error(Loc::current(), "The instance power file header is incomplete!");
-  }
-  std::array<char, 8> expected_magic = {'I', 'S', 'T', 'A', 'P', 'W', 'R', '\0'};
-  if (!std::equal(std::begin(magic), std::end(magic), expected_magic.begin())) {
-    EMIRLOG.error(Loc::current(), "The instance power file magic is invalid!");
-  }
-  if (version != 1) {
-    EMIRLOG.error(Loc::current(), "The instance power file version is invalid!");
-  }
-  if (record_size != 44) {
-    EMIRLOG.error(Loc::current(), "The instance power file record size is invalid!");
+  double power_coverage = 100.0 * matched_total_power / report_total_power;
+  EMIRLOG.info(Loc::current(), "Loaded shared PT-PX power: matched_instances=", instance_power_map.size(), ", unknown_records=",
+               unknown_record_num, ", power_coverage=", power_coverage, "% from ", _config.ptpx_instance_power_file_path);
+  if (power_coverage < 95.0) {
+    EMIRLOG.error(Loc::current(), "PT-PX instance power coverage is below 95%: ", power_coverage, "%");
   }
 }
 
-void DataManager::readInstancePowerRecord(std::ifstream* instance_power_file)
+void DataManager::readEMTech()
 {
-  InstancePower instance_power;
-  uint64_t instance_id = 0;
-  uint32_t power_group_type = 0;
-  double voltage = 0.0;
-  double internal_power = 0.0;
-  double switching_power = 0.0;
-  double leakage_power = 0.0;
-  instance_power_file->read(reinterpret_cast<char*>(&instance_id), static_cast<std::streamsize>(sizeof(instance_id)));
-  instance_power_file->read(reinterpret_cast<char*>(&power_group_type), static_cast<std::streamsize>(sizeof(power_group_type)));
-  instance_power_file->read(reinterpret_cast<char*>(&voltage), static_cast<std::streamsize>(sizeof(voltage)));
-  instance_power_file->read(reinterpret_cast<char*>(&internal_power), static_cast<std::streamsize>(sizeof(internal_power)));
-  instance_power_file->read(reinterpret_cast<char*>(&switching_power), static_cast<std::streamsize>(sizeof(switching_power)));
-  instance_power_file->read(reinterpret_cast<char*>(&leakage_power), static_cast<std::streamsize>(sizeof(leakage_power)));
-  if (!(*instance_power_file)) {
-    EMIRLOG.error(Loc::current(), "The instance power file record is incomplete!");
+  _database.get_em_tech().clear();
+  if (_config.redhawk_tech_file_path.empty() && _config.em_limit_file_path.empty()) {
+    EMIRLOG.warn(Loc::current(), "EM tech is not configured; EM_Ratio will be reported as 0%.");
+    return;
   }
-  if (_database.get_instance_id_set().count(instance_id) == 0) {
-    EMIRLOG.error(Loc::current(), "The instance power file references an unknown instance!");
+  if (!_config.redhawk_tech_file_path.empty()) {
+    readRedHawkTechFile(_config.redhawk_tech_file_path);
   }
-  if (_database.get_instance_power_map().count(instance_id) != 0) {
-    EMIRLOG.error(Loc::current(), "The instance power file contains duplicate instance records!");
+  if (!_config.em_limit_file_path.empty()) {
+    readEMLimitFile(_config.em_limit_file_path);
   }
-  instance_power.set_instance_id(instance_id);
-  instance_power.set_power_group_type(power_group_type);
-  instance_power.set_voltage(voltage);
-  instance_power.set_internal_power(internal_power);
-  instance_power.set_switching_power(switching_power);
-  instance_power.set_leakage_power(leakage_power);
-  _database.get_instance_power_map()[instance_id] = instance_power;
+  if (!_database.get_em_tech().get_has_rule()) {
+    EMIRLOG.warn(Loc::current(), "No EM rule was parsed; EM_Ratio will be reported as 0%.");
+    return;
+  }
+  EMIRLOG.info(Loc::current(), "Loaded EM tech rules from ", _database.get_em_tech().get_source_file_path(), ": metal=",
+               _database.get_em_tech().get_metal_rule_map().size(), ", via=", _database.get_em_tech().get_via_rule_map().size());
+}
+
+void DataManager::readRedHawkTechFile(const std::string& redhawk_tech_file_path)
+{
+  if (!std::filesystem::is_regular_file(redhawk_tech_file_path)) {
+    EMIRLOG.error(Loc::current(), "The RedHawk tech file is missing: ", redhawk_tech_file_path);
+  }
+  EMTech& em_tech = _database.get_em_tech();
+  em_tech.set_source_file_path(redhawk_tech_file_path);
+  std::vector<std::string> tokens = tokenizeRedHawkTechFile(redhawk_tech_file_path);
+  for (std::size_t token_idx = 0; token_idx + 1 < tokens.size(); token_idx++) {
+    if (toUpper(tokens[token_idx]) != "HALF_NODE_SCALE_FACTOR") {
+      continue;
+    }
+    double scale_factor = 0.0;
+    if (parseDouble(tokens[token_idx + 1], scale_factor) && scale_factor > 0.0) {
+      em_tech.set_half_node_scale_factor(scale_factor);
+    }
+  }
+  for (std::size_t token_idx = 0; token_idx + 2 < tokens.size(); token_idx++) {
+    std::string block_type = toUpper(tokens[token_idx]);
+    if (block_type != "METAL" && block_type != "VIA") {
+      continue;
+    }
+    std::string rule_name = tokens[token_idx + 1];
+    if (tokens[token_idx + 2] != "{") {
+      continue;
+    }
+    std::size_t cursor = token_idx + 3;
+    int32_t depth = 1;
+    double em_limit = 0.0;
+    double em_adjust = 0.0;
+    double area = 0.0;
+    while (cursor < tokens.size() && depth > 0) {
+      std::string key = toUpper(tokens[cursor]);
+      if (tokens[cursor] == "{") {
+        depth++;
+      } else if (tokens[cursor] == "}") {
+        depth--;
+      } else if (depth == 1 && cursor + 1 < tokens.size()) {
+        double value = 0.0;
+        if ((key == "EM" || key == "EM_ADJUST" || key == "AREA") && parseDouble(tokens[cursor + 1], value)) {
+          if (key == "EM") {
+            em_limit = value;
+          } else if (key == "EM_ADJUST") {
+            em_adjust = value;
+          } else if (key == "AREA") {
+            area = value;
+          }
+          cursor++;
+        }
+      }
+      cursor++;
+    }
+    if (block_type == "METAL") {
+      addMetalRule(em_tech, rule_name, em_limit, em_adjust);
+    } else {
+      addViaRule(em_tech, rule_name, em_limit, area);
+    }
+    if (cursor > 0) {
+      token_idx = cursor - 1;
+    }
+  }
+}
+
+void DataManager::readEMLimitFile(const std::string& em_limit_file_path)
+{
+  if (!std::filesystem::is_regular_file(em_limit_file_path)) {
+    EMIRLOG.error(Loc::current(), "The EM limit file is missing: ", em_limit_file_path);
+  }
+  EMTech& em_tech = _database.get_em_tech();
+  em_tech.set_source_file_path(em_limit_file_path);
+  std::ifstream input(em_limit_file_path);
+  std::string line;
+  while (std::getline(input, line)) {
+    std::size_t comment_pos = line.find('#');
+    if (comment_pos != std::string::npos) {
+      line = line.substr(0, comment_pos);
+    }
+    line = trim(line);
+    if (line.empty()) {
+      continue;
+    }
+    std::istringstream iss(line);
+    std::string name;
+    double em_limit = 0.0;
+    double em_adjust = 0.0;
+    iss >> name >> em_limit;
+    if (name.empty() || em_limit <= 0.0) {
+      continue;
+    }
+    iss >> em_adjust;
+    std::string normalized_name = normalizeRuleName(name);
+    if (normalized_name.rfind("M", 0) == 0 || normalized_name.rfind("MET", 0) == 0 || normalized_name == "TM" || normalized_name == "T4M2"
+        || normalized_name == "RDL") {
+      addMetalRule(em_tech, name, em_limit, em_adjust);
+    } else {
+      addViaRule(em_tech, name, em_limit, 0.0);
+    }
+  }
 }
 
 #endif
@@ -213,8 +507,18 @@ void DataManager::printConfig()
   EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(0), "EMIR_CONFIG_INPUT");
   EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "temp_directory_path");
   EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _config.temp_directory_path);
-  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "instance_power_file_path");
-  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _config.instance_power_file_path);
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "ptpx_instance_power_file_path");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _config.ptpx_instance_power_file_path);
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "redhawk_res_network_file_path");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _config.redhawk_res_network_file_path);
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "ploc_file_path");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _config.ploc_file_path);
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "redhawk_tech_file_path");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _config.redhawk_tech_file_path);
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "em_limit_file_path");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _config.em_limit_file_path);
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "em_violation_threshold_percent");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _config.em_violation_threshold_percent);
   EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "thread_number");
   EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _config.thread_number);
 }
@@ -228,6 +532,14 @@ void DataManager::printDatabase()
   EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _database.get_power_net_map().size());
   EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "instance_power_num");
   EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _database.get_instance_power_map().size());
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "power_source_num");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _database.get_power_source_list().size());
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "em_tech_metal_rule_num");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _database.get_em_tech().get_metal_rule_map().size());
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "em_tech_via_rule_num");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _database.get_em_tech().get_via_rule_map().size());
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(1), "half_node_scale_factor");
+  EMIRLOG.info(Loc::current(), EMIRUTIL.getSpaceByTabNum(2), _database.get_em_tech().get_half_node_scale_factor());
 }
 
 #endif

--- a/src/operation/iEMIR/source/data_manager/DataManager.hpp
+++ b/src/operation/iEMIR/source/data_manager/DataManager.hpp
@@ -55,8 +55,10 @@ class DataManager
   void buildConfig();
   void buildDatabase();
   void readInstancePower();
-  void readInstancePowerHeader(std::ifstream* instance_power_file, uint64_t& instance_power_num);
-  void readInstancePowerRecord(std::ifstream* instance_power_file);
+  void readPowerSourceFile();
+  void readEMTech();
+  void readRedHawkTechFile(const std::string& redhawk_tech_file_path);
+  void readEMLimitFile(const std::string& em_limit_file_path);
   void printConfig();
   void printDatabase();
 };

--- a/src/operation/iEMIR/source/data_manager/PTPXPowerReader.cpp
+++ b/src/operation/iEMIR/source/data_manager/PTPXPowerReader.cpp
@@ -1,0 +1,140 @@
+// ***************************************************************************************
+// Copyright (c) 2023-2025 Peng Cheng Laboratory
+// Copyright (c) 2023-2025 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2023-2025 Beijing Institute of Open Source Chip
+//
+// iEDA is licensed under Mulan PSL v2.
+// ***************************************************************************************
+#include "PTPXPowerReader.hpp"
+
+namespace {
+
+constexpr const char* kFormatMarker = "# iEMIR_PTPX_INSTANCE_POWER_V1";
+constexpr const char* kHeader
+    = "instance_name\tvoltage_v\tinternal_power_w\tswitching_power_w\tleakage_power_w\ttotal_power_w\taverage_current_a";
+
+std::string trim(const std::string& text)
+{
+  std::size_t begin = 0;
+  while (begin < text.size() && std::isspace(static_cast<unsigned char>(text[begin]))) {
+    begin++;
+  }
+  std::size_t end = text.size();
+  while (end > begin && std::isspace(static_cast<unsigned char>(text[end - 1]))) {
+    end--;
+  }
+  return text.substr(begin, end - begin);
+}
+
+std::vector<std::string> splitTab(const std::string& line)
+{
+  std::vector<std::string> result;
+  std::istringstream stream(line);
+  std::string token;
+  while (std::getline(stream, token, '\t')) {
+    result.push_back(token);
+  }
+  return result;
+}
+
+double parseNonnegative(const std::string& text, const std::string& field, std::size_t line_number)
+{
+  std::size_t parsed = 0;
+  double value = 0.0;
+  try {
+    value = std::stod(text, &parsed);
+  } catch (const std::exception&) {
+    throw std::runtime_error("Invalid " + field + " at line " + std::to_string(line_number) + ": " + text);
+  }
+  if (parsed != text.size() || !std::isfinite(value) || value < 0.0) {
+    throw std::runtime_error("Invalid " + field + " at line " + std::to_string(line_number) + ": " + text);
+  }
+  return value;
+}
+
+bool closeEnough(double lhs, double rhs)
+{
+  return std::abs(lhs - rhs) <= std::max(1.0e-18, 1.0e-6 * std::max(std::abs(lhs), std::abs(rhs)));
+}
+
+}  // namespace
+
+namespace iemir {
+
+std::vector<PTPXPowerRecord> PTPXPowerReader::read(const std::string& file_path)
+{
+  std::ifstream input(file_path);
+  if (!input.is_open()) {
+    throw std::runtime_error("Cannot open PT-PX instance power file: " + file_path);
+  }
+
+  std::vector<PTPXPowerRecord> records;
+  std::unordered_set<std::string> instance_names;
+  std::string line;
+  std::size_t line_number = 0;
+  bool saw_marker = false;
+  bool saw_header = false;
+  while (std::getline(input, line)) {
+    line_number++;
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+    if (!saw_header && line == kFormatMarker) {
+      saw_marker = true;
+      continue;
+    }
+    if (!saw_header && line == kHeader) {
+      saw_header = true;
+      continue;
+    }
+    std::string stripped = trim(line);
+    if (stripped.empty() || stripped.front() == '#') {
+      continue;
+    }
+    if (!saw_header) {
+      throw std::runtime_error("Missing PT-PX column header before line " + std::to_string(line_number));
+    }
+
+    std::vector<std::string> fields = splitTab(line);
+    if (fields.size() != 7) {
+      throw std::runtime_error("Expected 7 tab-separated fields at line " + std::to_string(line_number));
+    }
+    PTPXPowerRecord record;
+    record.instance_name = trim(fields[0]);
+    if (record.instance_name.empty()) {
+      throw std::runtime_error("Empty instance name at line " + std::to_string(line_number));
+    }
+    if (!instance_names.insert(record.instance_name).second) {
+      throw std::runtime_error("Duplicate instance name at line " + std::to_string(line_number) + ": " + record.instance_name);
+    }
+    record.voltage = parseNonnegative(fields[1], "voltage_v", line_number);
+    record.internal_power = parseNonnegative(fields[2], "internal_power_w", line_number);
+    record.switching_power = parseNonnegative(fields[3], "switching_power_w", line_number);
+    record.leakage_power = parseNonnegative(fields[4], "leakage_power_w", line_number);
+    record.total_power = parseNonnegative(fields[5], "total_power_w", line_number);
+    record.average_current = parseNonnegative(fields[6], "average_current_a", line_number);
+    if (record.voltage <= 0.0) {
+      throw std::runtime_error("Non-positive voltage at line " + std::to_string(line_number));
+    }
+    double component_power = record.internal_power + record.switching_power + record.leakage_power;
+    if (!closeEnough(component_power, record.total_power)) {
+      throw std::runtime_error("Power components do not match total_power_w at line " + std::to_string(line_number));
+    }
+    if (!closeEnough(record.voltage * record.average_current, record.total_power)) {
+      throw std::runtime_error("voltage_v * average_current_a does not match total_power_w at line " + std::to_string(line_number));
+    }
+    records.push_back(std::move(record));
+  }
+  if (!saw_marker) {
+    throw std::runtime_error("Missing PT-PX format marker: " + std::string(kFormatMarker));
+  }
+  if (!saw_header) {
+    throw std::runtime_error("Missing PT-PX column header in " + file_path);
+  }
+  if (records.empty()) {
+    throw std::runtime_error("No PT-PX instance power records in " + file_path);
+  }
+  return records;
+}
+
+}  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/PTPXPowerReader.hpp
+++ b/src/operation/iEMIR/source/data_manager/PTPXPowerReader.hpp
@@ -1,0 +1,31 @@
+// ***************************************************************************************
+// Copyright (c) 2023-2025 Peng Cheng Laboratory
+// Copyright (c) 2023-2025 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2023-2025 Beijing Institute of Open Source Chip
+//
+// iEDA is licensed under Mulan PSL v2.
+// ***************************************************************************************
+#pragma once
+
+#include "EMIRHeader.hpp"
+
+namespace iemir {
+
+struct PTPXPowerRecord
+{
+  std::string instance_name;
+  double voltage = 0.0;
+  double internal_power = 0.0;
+  double switching_power = 0.0;
+  double leakage_power = 0.0;
+  double total_power = 0.0;
+  double average_current = 0.0;
+};
+
+class PTPXPowerReader
+{
+ public:
+  static std::vector<PTPXPowerRecord> read(const std::string& file_path);
+};
+
+}  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/RedHawkResNetworkReader.cpp
+++ b/src/operation/iEMIR/source/data_manager/RedHawkResNetworkReader.cpp
@@ -1,0 +1,274 @@
+#include "RedHawkResNetworkReader.hpp"
+
+namespace {
+
+struct WireRecord
+{
+  std::string id;
+  std::string layer_name;
+  std::string net_name;
+  double width_um = 0.0;
+};
+
+struct WireSegmentFields
+{
+  std::string id;
+  std::string parent_id;
+  double first_x_um = 0.0;
+  double first_y_um = 0.0;
+  double second_x_um = 0.0;
+  double second_y_um = 0.0;
+  double resistance_ohm = 0.0;
+  std::size_t line_number = 0;
+};
+
+std::vector<std::string> splitWhitespace(const std::string& line)
+{
+  std::vector<std::string> fields;
+  std::istringstream stream(line);
+  std::string field;
+  while (stream >> field) {
+    fields.push_back(std::move(field));
+  }
+  return fields;
+}
+
+double parsePositiveDouble(const std::string& text, const std::string& field_name, std::size_t line_number)
+{
+  std::size_t parsed_size = 0;
+  double value = 0.0;
+  try {
+    value = std::stod(text, &parsed_size);
+  } catch (const std::exception&) {
+    throw std::runtime_error("Invalid " + field_name + " at line " + std::to_string(line_number) + ": " + text);
+  }
+  if (parsed_size != text.size() || !std::isfinite(value) || value <= 0.0) {
+    throw std::runtime_error("Invalid " + field_name + " at line " + std::to_string(line_number) + ": " + text);
+  }
+  return value;
+}
+
+double parseCoordinate(const std::string& text, const std::string& field_name, std::size_t line_number)
+{
+  std::size_t parsed_size = 0;
+  double value = 0.0;
+  try {
+    value = std::stod(text, &parsed_size);
+  } catch (const std::exception&) {
+    throw std::runtime_error("Invalid " + field_name + " at line " + std::to_string(line_number) + ": " + text);
+  }
+  if (parsed_size != text.size() || !std::isfinite(value)) {
+    throw std::runtime_error("Invalid " + field_name + " at line " + std::to_string(line_number) + ": " + text);
+  }
+  return value;
+}
+
+int32_t parsePositiveInteger(const std::string& text, const std::string& field_name, std::size_t line_number)
+{
+  std::size_t parsed_size = 0;
+  long value = 0;
+  try {
+    value = std::stol(text, &parsed_size);
+  } catch (const std::exception&) {
+    throw std::runtime_error("Invalid " + field_name + " at line " + std::to_string(line_number) + ": " + text);
+  }
+  if (parsed_size != text.size() || value <= 0 || value > std::numeric_limits<int32_t>::max()) {
+    throw std::runtime_error("Invalid " + field_name + " at line " + std::to_string(line_number) + ": " + text);
+  }
+  return static_cast<int32_t>(value);
+}
+
+std::string getParentWireId(const std::string& segment_id, std::size_t line_number)
+{
+  std::size_t delimiter_position = segment_id.rfind('_');
+  if (delimiter_position == std::string::npos || delimiter_position == 0 || delimiter_position + 1 == segment_id.size()) {
+    throw std::runtime_error("Invalid WS identifier at line " + std::to_string(line_number) + ": " + segment_id);
+  }
+  return segment_id.substr(0, delimiter_position);
+}
+
+}  // namespace
+
+namespace iemir {
+
+RedHawkResNetwork RedHawkResNetworkReader::read(const std::string& file_path)
+{
+  std::ifstream input(file_path);
+  if (!input.is_open()) {
+    throw std::runtime_error("Cannot open RedHawk res_network file: " + file_path);
+  }
+
+  RedHawkResNetwork network;
+  std::vector<WireRecord> wires;
+  std::unordered_map<std::string, std::size_t> wire_index_by_id;
+  std::vector<WireSegmentFields> wire_segments;
+  std::unordered_set<std::string> wire_segment_ids;
+  std::unordered_set<std::string> via_ids;
+  std::string line;
+  std::size_t line_number = 0;
+  while (std::getline(input, line)) {
+    line_number++;
+    std::vector<std::string> fields = splitWhitespace(line);
+    if (fields.empty() || fields.front().front() == '#') {
+      continue;
+    }
+
+    if (fields[0] == "W") {
+      if (fields.size() != 15) {
+        throw std::runtime_error("Expected 15 fields for W at line " + std::to_string(line_number));
+      }
+      WireRecord wire;
+      wire.id = fields[1];
+      wire.layer_name = fields[2];
+      wire.net_name = fields[3];
+      for (std::size_t index = 0; index < 4; index++) {
+        parseCoordinate(fields[4 + index * 2], "W x coordinate", line_number);
+        parseCoordinate(fields[5 + index * 2], "W y coordinate", line_number);
+      }
+      wire.width_um = parsePositiveDouble(fields[12], "W width", line_number);
+      parsePositiveDouble(fields[13], "W resistance", line_number);
+      if (fields[14].size() != 1 || (fields[14][0] != 'h' && fields[14][0] != 'v')) {
+        throw std::runtime_error("Invalid W direction at line " + std::to_string(line_number) + ": " + fields[14]);
+      }
+      if (!wire_index_by_id.emplace(wire.id, wires.size()).second) {
+        throw std::runtime_error("Duplicate W identifier at line " + std::to_string(line_number) + ": " + wire.id);
+      }
+      wires.push_back(std::move(wire));
+      continue;
+    }
+
+    if (fields[0] == "WS") {
+      if (fields.size() != 12) {
+        throw std::runtime_error("Expected 12 fields for WS at line " + std::to_string(line_number));
+      }
+      WireSegmentFields segment;
+      segment.id = fields[1];
+      if (!wire_segment_ids.insert(segment.id).second) {
+        throw std::runtime_error("Duplicate WS identifier at line " + std::to_string(line_number) + ": " + segment.id);
+      }
+      segment.parent_id = getParentWireId(segment.id, line_number);
+      segment.first_x_um = parseCoordinate(fields[2], "WS first x coordinate", line_number);
+      segment.first_y_um = parseCoordinate(fields[3], "WS first y coordinate", line_number);
+      segment.second_x_um = parseCoordinate(fields[4], "WS second x coordinate", line_number);
+      segment.second_y_um = parseCoordinate(fields[5], "WS second y coordinate", line_number);
+      segment.resistance_ohm = parsePositiveDouble(fields[10], "WS resistance", line_number);
+      segment.line_number = line_number;
+      wire_segments.push_back(std::move(segment));
+      continue;
+    }
+
+    if (fields[0] == "V") {
+      if (fields.size() < 18) {
+        throw std::runtime_error("Expected at least 18 fields for V at line " + std::to_string(line_number));
+      }
+      RedHawkViaRecord via;
+      via.id = fields[1];
+      via.layer_name = fields[2];
+      via.via_name = fields[3];
+      via.net_name = fields[4];
+      via.x_um = parseCoordinate(fields[5], "V x coordinate", line_number);
+      via.y_um = parseCoordinate(fields[6], "V y coordinate", line_number);
+      via.cut_num = parsePositiveInteger(fields[7], "V cut count", line_number);
+      via.cut_width_um = parsePositiveDouble(fields[8], "V cut width", line_number);
+      via.cut_height_um = parsePositiveDouble(fields[9], "V cut height", line_number);
+      via.resistance_ohm = parsePositiveDouble(fields[10], "V resistance", line_number);
+      via.connected_wire_segment_ids.assign(fields.begin() + 18, fields.end());
+      if (!via_ids.insert(via.id).second) {
+        throw std::runtime_error("Duplicate V identifier at line " + std::to_string(line_number) + ": " + via.id);
+      }
+      network.vias.push_back(std::move(via));
+      continue;
+    }
+
+    throw std::runtime_error("Unknown RedHawk res_network record at line " + std::to_string(line_number) + ": " + fields[0]);
+  }
+
+  for (const WireSegmentFields& segment_fields : wire_segments) {
+    auto wire_iter = wire_index_by_id.find(segment_fields.parent_id);
+    if (wire_iter == wire_index_by_id.end()) {
+      throw std::runtime_error("WS references unknown W at line " + std::to_string(segment_fields.line_number) + ": "
+                               + segment_fields.parent_id);
+    }
+    WireRecord& wire = wires[wire_iter->second];
+    RedHawkWireSegmentRecord segment;
+    segment.id = segment_fields.id;
+    segment.layer_name = wire.layer_name;
+    segment.net_name = wire.net_name;
+    segment.first_x_um = segment_fields.first_x_um;
+    segment.first_y_um = segment_fields.first_y_um;
+    segment.second_x_um = segment_fields.second_x_um;
+    segment.second_y_um = segment_fields.second_y_um;
+    segment.width_um = wire.width_um;
+    segment.resistance_ohm = segment_fields.resistance_ohm;
+    network.wire_segments.push_back(std::move(segment));
+  }
+  if (network.wire_segments.empty()) {
+    throw std::runtime_error("No wire resistance records in RedHawk res_network file: " + file_path);
+  }
+  return network;
+}
+
+}  // namespace iemir
+
+namespace iemir {
+
+std::optional<std::pair<double, double>> RedHawkResNetworkReader::connectionCoordinate(
+    const RedHawkViaRecord& via, const std::unordered_map<std::string, const RedHawkWireSegmentRecord*>& wire_segment_map,
+    const std::string& layer_name)
+{
+  // The listed resistors describe the electrical junction. When multiple
+  // segments share an endpoint, that endpoint takes precedence over the via
+  // shape's center projection (which can lie on the adjoining pad segment).
+  std::set<std::pair<double, double>> common_endpoints;
+  std::size_t connected_segments = 0;
+  for (const std::string& segment_id : via.connected_wire_segment_ids) {
+    auto iter = wire_segment_map.find(segment_id);
+    if (iter == wire_segment_map.end() || iter->second->layer_name != layer_name || iter->second->net_name != via.net_name) {
+      continue;
+    }
+    const auto& segment = *iter->second;
+    std::set<std::pair<double, double>> endpoints{{segment.first_x_um, segment.first_y_um}, {segment.second_x_um, segment.second_y_um}};
+    if (connected_segments++ == 0) {
+      common_endpoints = endpoints;
+    } else {
+      for (auto endpoint = common_endpoints.begin(); endpoint != common_endpoints.end();) {
+        if (endpoints.count(*endpoint) == 0) {
+          endpoint = common_endpoints.erase(endpoint);
+        } else {
+          ++endpoint;
+        }
+      }
+    }
+  }
+  if (connected_segments > 1 && common_endpoints.size() == 1) {
+    return *common_endpoints.begin();
+  }
+  std::optional<std::pair<double, double>> result;
+  double minimum_distance_squared = std::numeric_limits<double>::max();
+  for (const std::string& segment_id : via.connected_wire_segment_ids) {
+    auto segment_iter = wire_segment_map.find(segment_id);
+    if (segment_iter == wire_segment_map.end() || segment_iter->second->layer_name != layer_name
+        || segment_iter->second->net_name != via.net_name) {
+      continue;
+    }
+    const RedHawkWireSegmentRecord& segment = *segment_iter->second;
+    double dx = segment.second_x_um - segment.first_x_um;
+    double dy = segment.second_y_um - segment.first_y_um;
+    double length_squared = dx * dx + dy * dy;
+    if (length_squared <= std::numeric_limits<double>::epsilon()) {
+      continue;
+    }
+    double projection = ((via.x_um - segment.first_x_um) * dx + (via.y_um - segment.first_y_um) * dy) / length_squared;
+    projection = std::clamp(projection, 0.0, 1.0);
+    double projected_x = segment.first_x_um + projection * dx;
+    double projected_y = segment.first_y_um + projection * dy;
+    double distance_squared = (via.x_um - projected_x) * (via.x_um - projected_x) + (via.y_um - projected_y) * (via.y_um - projected_y);
+    if (distance_squared < minimum_distance_squared) {
+      minimum_distance_squared = distance_squared;
+      result = std::make_pair(projected_x, projected_y);
+    }
+  }
+  return result;
+}
+
+}  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/RedHawkResNetworkReader.hpp
+++ b/src/operation/iEMIR/source/data_manager/RedHawkResNetworkReader.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "EMIRHeader.hpp"
+
+namespace iemir {
+
+struct RedHawkWireSegmentRecord
+{
+  std::string id;
+  std::string layer_name;
+  std::string net_name;
+  double first_x_um = 0.0;
+  double first_y_um = 0.0;
+  double second_x_um = 0.0;
+  double second_y_um = 0.0;
+  double width_um = 0.0;
+  double resistance_ohm = 0.0;
+};
+
+struct RedHawkViaRecord
+{
+  std::string id;
+  std::string layer_name;
+  std::string via_name;
+  std::string net_name;
+  double x_um = 0.0;
+  double y_um = 0.0;
+  int32_t cut_num = 0;
+  double cut_width_um = 0.0;
+  double cut_height_um = 0.0;
+  double resistance_ohm = 0.0;
+  std::vector<std::string> connected_wire_segment_ids;
+};
+
+struct RedHawkResNetwork
+{
+  std::vector<RedHawkWireSegmentRecord> wire_segments;
+  std::vector<RedHawkViaRecord> vias;
+};
+
+class RedHawkResNetworkReader
+{
+ public:
+  static RedHawkResNetwork read(const std::string& file_path);
+  static std::optional<std::pair<double, double>> connectionCoordinate(
+      const RedHawkViaRecord& via, const std::unordered_map<std::string, const RedHawkWireSegmentRecord*>& wire_segment_map,
+      const std::string& layer_name);
+};
+
+}  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/advance/Config.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/Config.hpp
@@ -35,7 +35,12 @@ class Config
   /////////////////////////////////////////////
   // **********       EMIR        ********** //
   std::string temp_directory_path;
-  std::string instance_power_file_path;
+  std::string ptpx_instance_power_file_path;
+  std::string redhawk_res_network_file_path;
+  std::string ploc_file_path;
+  std::string redhawk_tech_file_path;
+  std::string em_limit_file_path;
+  double em_violation_threshold_percent = 100.0;
   int32_t thread_number;
   /////////////////////////////////////////////
   // **********       EMIR        ********** //

--- a/src/operation/iEMIR/source/data_manager/advance/Database.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/Database.hpp
@@ -16,10 +16,12 @@
 // ***************************************************************************************
 #pragma once
 
+#include "EMTech.hpp"
 #include "EMIRHeader.hpp"
 #include "InstancePower.hpp"
 #include "PowerGraph.hpp"
 #include "PowerNet.hpp"
+#include "PowerSource.hpp"
 
 namespace iemir {
 
@@ -32,9 +34,12 @@ class Database
   std::string& get_design_name() { return _design_name; }
   int32_t get_micron_dbu() { return _micron_dbu; }
   std::set<uint64_t>& get_instance_id_set() { return _instance_id_set; }
+  std::map<std::string, uint64_t>& get_instance_name_to_id_map() { return _instance_name_to_id_map; }
   std::map<std::string, PowerNet>& get_power_net_map() { return _power_net_map; }
+  std::vector<PowerSource>& get_power_source_list() { return _power_source_list; }
   std::map<uint64_t, InstancePower>& get_instance_power_map() { return _instance_power_map; }
   std::map<std::string, PowerGraph>& get_power_graph_map() { return _power_graph_map; }
+  EMTech& get_em_tech() { return _em_tech; }
   // setter
   void set_design_name(const std::string& design_name) { _design_name = design_name; }
   void set_micron_dbu(int32_t micron_dbu) { _micron_dbu = micron_dbu; }
@@ -44,9 +49,12 @@ class Database
   std::string _design_name;
   int32_t _micron_dbu = 0;
   std::set<uint64_t> _instance_id_set;
+  std::map<std::string, uint64_t> _instance_name_to_id_map;
   std::map<std::string, PowerNet> _power_net_map;
+  std::vector<PowerSource> _power_source_list;
   std::map<uint64_t, InstancePower> _instance_power_map;
   std::map<std::string, PowerGraph> _power_graph_map;
+  EMTech _em_tech;
 };
 
 }  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/advance/EMTech.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/EMTech.hpp
@@ -1,0 +1,95 @@
+// ***************************************************************************************
+// Copyright (c) 2023-2025 Peng Cheng Laboratory
+// Copyright (c) 2023-2025 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2023-2025 Beijing Institute of Open Source Chip
+//
+// iEDA is licensed under Mulan PSL v2.
+// You can use this software according to the terms and conditions of the Mulan PSL v2.
+// You may obtain a copy of Mulan PSL v2 at:
+// http://license.coscl.org.cn/MulanPSL2
+//
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+// MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+//
+// See the Mulan PSL v2 for more details.
+// ***************************************************************************************
+#pragma once
+
+#include "EMIRHeader.hpp"
+
+namespace iemir {
+
+class EMMetalRule
+{
+ public:
+  EMMetalRule() = default;
+  ~EMMetalRule() = default;
+  // getter
+  std::string& get_name() { return _name; }
+  double get_em_limit_ma_per_um() { return _em_limit_ma_per_um; }
+  double get_em_adjust_um() { return _em_adjust_um; }
+  // setter
+  void set_name(const std::string& name) { _name = name; }
+  void set_em_limit_ma_per_um(double em_limit_ma_per_um) { _em_limit_ma_per_um = em_limit_ma_per_um; }
+  void set_em_adjust_um(double em_adjust_um) { _em_adjust_um = em_adjust_um; }
+  // function
+
+ private:
+  std::string _name;
+  double _em_limit_ma_per_um = 0.0;
+  double _em_adjust_um = 0.0;
+};
+
+class EMViaRule
+{
+ public:
+  EMViaRule() = default;
+  ~EMViaRule() = default;
+  // getter
+  std::string& get_name() { return _name; }
+  double get_em_limit_ma() { return _em_limit_ma; }
+  double get_reference_area_um2() { return _reference_area_um2; }
+  // setter
+  void set_name(const std::string& name) { _name = name; }
+  void set_em_limit_ma(double em_limit_ma) { _em_limit_ma = em_limit_ma; }
+  void set_reference_area_um2(double reference_area_um2) { _reference_area_um2 = reference_area_um2; }
+  // function
+
+ private:
+  std::string _name;
+  double _em_limit_ma = 0.0;
+  double _reference_area_um2 = 0.0;
+};
+
+class EMTech
+{
+ public:
+  EMTech() = default;
+  ~EMTech() = default;
+  // getter
+  std::string& get_source_file_path() { return _source_file_path; }
+  std::map<std::string, EMMetalRule>& get_metal_rule_map() { return _metal_rule_map; }
+  std::map<std::string, EMViaRule>& get_via_rule_map() { return _via_rule_map; }
+  double get_half_node_scale_factor() { return _half_node_scale_factor; }
+  bool get_has_rule() { return !_metal_rule_map.empty() || !_via_rule_map.empty(); }
+  // setter
+  void set_source_file_path(const std::string& source_file_path) { _source_file_path = source_file_path; }
+  void set_half_node_scale_factor(double half_node_scale_factor) { _half_node_scale_factor = half_node_scale_factor; }
+  // function
+  void clear()
+  {
+    _source_file_path.clear();
+    _half_node_scale_factor = 1.0;
+    _metal_rule_map.clear();
+    _via_rule_map.clear();
+  }
+
+ private:
+  std::string _source_file_path;
+  double _half_node_scale_factor = 1.0;
+  std::map<std::string, EMMetalRule> _metal_rule_map;
+  std::map<std::string, EMViaRule> _via_rule_map;
+};
+
+}  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/advance/InstancePower.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/InstancePower.hpp
@@ -33,6 +33,9 @@ class InstancePower
   double get_switching_power() { return _switching_power; }
   double get_leakage_power() { return _leakage_power; }
   double get_total_power() { return _internal_power + _switching_power + _leakage_power; }
+  bool get_has_average_current() { return _has_average_current; }
+  double get_average_current() { return _average_current; }
+  std::map<std::string, double>& get_average_current_by_pin_name_map() { return _average_current_by_pin_name_map; }
   // setter
   void set_instance_id(uint64_t instance_id) { _instance_id = instance_id; }
   void set_power_group_type(uint32_t power_group_type) { _power_group_type = power_group_type; }
@@ -40,6 +43,11 @@ class InstancePower
   void set_internal_power(double internal_power) { _internal_power = internal_power; }
   void set_switching_power(double switching_power) { _switching_power = switching_power; }
   void set_leakage_power(double leakage_power) { _leakage_power = leakage_power; }
+  void set_average_current(double average_current)
+  {
+    _average_current = average_current;
+    _has_average_current = true;
+  }
   // function
 
  private:
@@ -49,6 +57,9 @@ class InstancePower
   double _internal_power = 0.0;
   double _switching_power = 0.0;
   double _leakage_power = 0.0;
+  bool _has_average_current = false;
+  double _average_current = 0.0;
+  std::map<std::string, double> _average_current_by_pin_name_map;
 };
 
 }  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/advance/PowerEdge.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/PowerEdge.hpp
@@ -32,24 +32,50 @@ class PowerEdge
   std::size_t get_first_node_id() { return _first_node_id; }
   std::size_t get_second_node_id() { return _second_node_id; }
   int32_t get_layer_idx() { return _layer_idx; }
+  std::string& get_layer_name() { return _layer_name; }
+  std::string& get_via_name() { return _via_name; }
   int32_t get_width() { return _width; }
   int32_t get_length() { return _length; }
+  int32_t get_cut_num() { return _cut_num; }
+  double get_cut_area_um2() { return _cut_area_um2; }
+  int32_t get_cut_low_x() { return _cut_low_x; }
+  int32_t get_cut_low_y() { return _cut_low_y; }
+  int32_t get_cut_high_x() { return _cut_high_x; }
+  int32_t get_cut_high_y() { return _cut_high_y; }
   double get_resistance() { return _resistance; }
   double get_current() { return _current; }
   double get_current_density() { return _current_density; }
+  double get_em_limit() { return _em_limit; }
+  double get_em_ratio_percent() { return _em_ratio_percent; }
+  std::string& get_em_rule_name() { return _em_rule_name; }
+  bool get_has_em_limit() { return _has_em_limit; }
   bool get_is_violation() { return _is_violation; }
+  bool get_is_em_checkable() { return _is_em_checkable; }
   // setter
   void set_edge_id(std::size_t edge_id) { _edge_id = edge_id; }
   void set_type(PowerEdgeType type) { _type = type; }
   void set_first_node_id(std::size_t first_node_id) { _first_node_id = first_node_id; }
   void set_second_node_id(std::size_t second_node_id) { _second_node_id = second_node_id; }
   void set_layer_idx(int32_t layer_idx) { _layer_idx = layer_idx; }
+  void set_layer_name(const std::string& layer_name) { _layer_name = layer_name; }
+  void set_via_name(const std::string& via_name) { _via_name = via_name; }
   void set_width(int32_t width) { _width = width; }
   void set_length(int32_t length) { _length = length; }
+  void set_cut_num(int32_t cut_num) { _cut_num = cut_num; }
+  void set_cut_area_um2(double cut_area_um2) { _cut_area_um2 = cut_area_um2; }
+  void set_cut_low_x(int32_t cut_low_x) { _cut_low_x = cut_low_x; }
+  void set_cut_low_y(int32_t cut_low_y) { _cut_low_y = cut_low_y; }
+  void set_cut_high_x(int32_t cut_high_x) { _cut_high_x = cut_high_x; }
+  void set_cut_high_y(int32_t cut_high_y) { _cut_high_y = cut_high_y; }
   void set_resistance(double resistance) { _resistance = resistance; }
   void set_current(double current) { _current = current; }
   void set_current_density(double current_density) { _current_density = current_density; }
+  void set_em_limit(double em_limit) { _em_limit = em_limit; }
+  void set_em_ratio_percent(double em_ratio_percent) { _em_ratio_percent = em_ratio_percent; }
+  void set_em_rule_name(const std::string& em_rule_name) { _em_rule_name = em_rule_name; }
+  void set_has_em_limit(bool has_em_limit) { _has_em_limit = has_em_limit; }
   void set_is_violation(bool is_violation) { _is_violation = is_violation; }
+  void set_is_em_checkable(bool is_em_checkable) { _is_em_checkable = is_em_checkable; }
   // function
 
  private:
@@ -58,12 +84,25 @@ class PowerEdge
   std::size_t _first_node_id = 0;
   std::size_t _second_node_id = 0;
   int32_t _layer_idx = -1;
+  std::string _layer_name;
+  std::string _via_name;
   int32_t _width = 0;
   int32_t _length = 0;
+  int32_t _cut_num = 0;
+  double _cut_area_um2 = 0.0;
+  int32_t _cut_low_x = 0;
+  int32_t _cut_low_y = 0;
+  int32_t _cut_high_x = 0;
+  int32_t _cut_high_y = 0;
   double _resistance = 0.0;
   double _current = 0.0;
   double _current_density = 0.0;
+  double _em_limit = 0.0;
+  double _em_ratio_percent = 0.0;
+  std::string _em_rule_name;
+  bool _has_em_limit = false;
   bool _is_violation = false;
+  bool _is_em_checkable = true;
 };
 
 }  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/advance/PowerGraph.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/PowerGraph.hpp
@@ -34,7 +34,17 @@ class PowerGraph
   std::vector<PowerNode>& get_node_list() { return _node_list; }
   std::vector<PowerEdge>& get_edge_list() { return _edge_list; }
   std::map<uint64_t, std::vector<std::size_t>>& get_instance_node_id_list_map() { return _instance_node_id_list_map; }
+  std::map<std::pair<uint64_t, std::string>, std::vector<std::size_t>>& get_instance_pin_node_id_list_map()
+  {
+    return _instance_pin_node_id_list_map;
+  }
+  std::map<uint64_t, std::map<std::size_t, double>>& get_instance_node_weight_map() { return _instance_node_weight_map; }
+  std::map<std::pair<uint64_t, std::string>, std::map<std::size_t, double>>& get_instance_pin_node_weight_map()
+  {
+    return _instance_pin_node_weight_map;
+  }
   std::vector<std::size_t>& get_source_node_id_list() { return _source_node_id_list; }
+  std::map<std::tuple<int32_t, int32_t, int32_t>, std::size_t>& get_coordinate_node_id_map() { return _coordinate_node_id_map; }
   bool get_is_connected() { return _is_connected; }
   double get_source_voltage() { return _source_voltage; }
   // setter
@@ -50,7 +60,11 @@ class PowerGraph
   std::vector<PowerNode> _node_list;
   std::vector<PowerEdge> _edge_list;
   std::map<uint64_t, std::vector<std::size_t>> _instance_node_id_list_map;
+  std::map<std::pair<uint64_t, std::string>, std::vector<std::size_t>> _instance_pin_node_id_list_map;
+  std::map<uint64_t, std::map<std::size_t, double>> _instance_node_weight_map;
+  std::map<std::pair<uint64_t, std::string>, std::map<std::size_t, double>> _instance_pin_node_weight_map;
   std::vector<std::size_t> _source_node_id_list;
+  std::map<std::tuple<int32_t, int32_t, int32_t>, std::size_t> _coordinate_node_id_map;
   bool _is_connected = false;
   double _source_voltage = 0.0;
 };

--- a/src/operation/iEMIR/source/data_manager/advance/PowerNet.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/PowerNet.hpp
@@ -35,9 +35,11 @@ class PowerNet
   std::vector<PowerWireSegment>& get_wire_segment_list() { return _wire_segment_list; }
   std::vector<PowerVia>& get_via_list() { return _via_list; }
   std::vector<PowerPin>& get_pin_list() { return _pin_list; }
+  bool get_has_explicit_parasitics() { return _has_explicit_parasitics; }
   // setter
   void set_net_name(const std::string& net_name) { _net_name = net_name; }
   void set_type(PowerNetType type) { _type = type; }
+  void set_has_explicit_parasitics(bool has_explicit_parasitics) { _has_explicit_parasitics = has_explicit_parasitics; }
   // function
 
  private:
@@ -46,6 +48,7 @@ class PowerNet
   std::vector<PowerWireSegment> _wire_segment_list;
   std::vector<PowerVia> _via_list;
   std::vector<PowerPin> _pin_list;
+  bool _has_explicit_parasitics = false;
 };
 
 }  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/advance/PowerPin.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/PowerPin.hpp
@@ -31,6 +31,10 @@ class PowerPin
   int32_t get_layer_idx() { return _layer_idx; }
   int32_t get_x() { return _x; }
   int32_t get_y() { return _y; }
+  int32_t get_low_x() { return _low_x; }
+  int32_t get_low_y() { return _low_y; }
+  int32_t get_high_x() { return _high_x; }
+  int32_t get_high_y() { return _high_y; }
   bool get_is_source() { return _is_source; }
   // setter
   void set_instance_id(uint64_t instance_id) { _instance_id = instance_id; }
@@ -38,6 +42,10 @@ class PowerPin
   void set_layer_idx(int32_t layer_idx) { _layer_idx = layer_idx; }
   void set_x(int32_t x) { _x = x; }
   void set_y(int32_t y) { _y = y; }
+  void set_low_x(int32_t low_x) { _low_x = low_x; }
+  void set_low_y(int32_t low_y) { _low_y = low_y; }
+  void set_high_x(int32_t high_x) { _high_x = high_x; }
+  void set_high_y(int32_t high_y) { _high_y = high_y; }
   void set_is_source(bool is_source) { _is_source = is_source; }
   // function
 
@@ -47,6 +55,10 @@ class PowerPin
   int32_t _layer_idx = -1;
   int32_t _x = 0;
   int32_t _y = 0;
+  int32_t _low_x = 0;
+  int32_t _low_y = 0;
+  int32_t _high_x = 0;
+  int32_t _high_y = 0;
   bool _is_source = false;
 };
 

--- a/src/operation/iEMIR/source/data_manager/advance/PowerSource.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/PowerSource.hpp
@@ -1,0 +1,41 @@
+// ***************************************************************************************
+// Copyright (c) 2023-2025 Peng Cheng Laboratory
+// Copyright (c) 2023-2025 Institute of Computing Technology, Chinese Academy of Sciences
+// Copyright (c) 2023-2025 Beijing Institute of Open Source Chip
+//
+// iEDA is licensed under Mulan PSL v2.
+// ***************************************************************************************
+#pragma once
+
+#include "EMIRHeader.hpp"
+#include "PowerNetType.hpp"
+
+namespace iemir {
+
+class PowerSource
+{
+ public:
+  std::string& get_name() { return _name; }
+  std::string& get_net_name() { return _net_name; }
+  std::string& get_layer_name() { return _layer_name; }
+  PowerNetType get_net_type() { return _net_type; }
+  int32_t get_x() { return _x; }
+  int32_t get_y() { return _y; }
+
+  void set_name(const std::string& name) { _name = name; }
+  void set_net_name(const std::string& net_name) { _net_name = net_name; }
+  void set_layer_name(const std::string& layer_name) { _layer_name = layer_name; }
+  void set_net_type(PowerNetType net_type) { _net_type = net_type; }
+  void set_x(int32_t x) { _x = x; }
+  void set_y(int32_t y) { _y = y; }
+
+ private:
+  std::string _name;
+  std::string _net_name;
+  std::string _layer_name;
+  PowerNetType _net_type = PowerNetType::kNone;
+  int32_t _x = 0;
+  int32_t _y = 0;
+};
+
+}  // namespace iemir

--- a/src/operation/iEMIR/source/data_manager/advance/PowerVia.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/PowerVia.hpp
@@ -26,27 +26,73 @@ class PowerVia
   PowerVia() = default;
   ~PowerVia() = default;
   // getter
+  std::string& get_via_name() { return _via_name; }
+  std::string& get_bottom_layer_name() { return _bottom_layer_name; }
+  std::string& get_top_layer_name() { return _top_layer_name; }
   int32_t get_bottom_layer_idx() { return _bottom_layer_idx; }
   int32_t get_top_layer_idx() { return _top_layer_idx; }
   int32_t get_x() { return _x; }
   int32_t get_y() { return _y; }
+  int32_t get_bottom_x() { return _bottom_x; }
+  int32_t get_bottom_y() { return _bottom_y; }
+  int32_t get_top_x() { return _top_x; }
+  int32_t get_top_y() { return _top_y; }
   int32_t get_cut_num() { return _cut_num; }
+  int32_t get_cut_low_x() { return _cut_low_x; }
+  int32_t get_cut_low_y() { return _cut_low_y; }
+  int32_t get_cut_high_x() { return _cut_high_x; }
+  int32_t get_cut_high_y() { return _cut_high_y; }
+  double get_cut_area_um2() { return _cut_area_um2; }
   double get_resistance() { return _resistance; }
   // setter
+  void set_via_name(const std::string& via_name) { _via_name = via_name; }
+  void set_bottom_layer_name(const std::string& bottom_layer_name) { _bottom_layer_name = bottom_layer_name; }
+  void set_top_layer_name(const std::string& top_layer_name) { _top_layer_name = top_layer_name; }
   void set_bottom_layer_idx(int32_t bottom_layer_idx) { _bottom_layer_idx = bottom_layer_idx; }
   void set_top_layer_idx(int32_t top_layer_idx) { _top_layer_idx = top_layer_idx; }
-  void set_x(int32_t x) { _x = x; }
-  void set_y(int32_t y) { _y = y; }
+  void set_x(int32_t x)
+  {
+    _x = x;
+    _bottom_x = x;
+    _top_x = x;
+  }
+  void set_y(int32_t y)
+  {
+    _y = y;
+    _bottom_y = y;
+    _top_y = y;
+  }
+  void set_bottom_x(int32_t bottom_x) { _bottom_x = bottom_x; }
+  void set_bottom_y(int32_t bottom_y) { _bottom_y = bottom_y; }
+  void set_top_x(int32_t top_x) { _top_x = top_x; }
+  void set_top_y(int32_t top_y) { _top_y = top_y; }
   void set_cut_num(int32_t cut_num) { _cut_num = cut_num; }
+  void set_cut_low_x(int32_t cut_low_x) { _cut_low_x = cut_low_x; }
+  void set_cut_low_y(int32_t cut_low_y) { _cut_low_y = cut_low_y; }
+  void set_cut_high_x(int32_t cut_high_x) { _cut_high_x = cut_high_x; }
+  void set_cut_high_y(int32_t cut_high_y) { _cut_high_y = cut_high_y; }
+  void set_cut_area_um2(double cut_area_um2) { _cut_area_um2 = cut_area_um2; }
   void set_resistance(double resistance) { _resistance = resistance; }
   // function
 
  private:
+  std::string _via_name;
+  std::string _bottom_layer_name;
+  std::string _top_layer_name;
   int32_t _bottom_layer_idx = -1;
   int32_t _top_layer_idx = -1;
   int32_t _x = 0;
   int32_t _y = 0;
+  int32_t _bottom_x = 0;
+  int32_t _bottom_y = 0;
+  int32_t _top_x = 0;
+  int32_t _top_y = 0;
   int32_t _cut_num = 0;
+  int32_t _cut_low_x = 0;
+  int32_t _cut_low_y = 0;
+  int32_t _cut_high_x = 0;
+  int32_t _cut_high_y = 0;
+  double _cut_area_um2 = 0.0;
   double _resistance = 0.0;
 };
 

--- a/src/operation/iEMIR/source/data_manager/advance/PowerWireSegment.hpp
+++ b/src/operation/iEMIR/source/data_manager/advance/PowerWireSegment.hpp
@@ -34,6 +34,9 @@ class PowerWireSegment
   int32_t get_second_y() { return _second_y; }
   int32_t get_width() { return _width; }
   double get_resistance_per_square() { return _resistance_per_square; }
+  double get_resistance() { return _resistance; }
+  bool get_has_explicit_resistance() { return _has_explicit_resistance; }
+  bool get_is_em_checkable() { return _is_em_checkable; }
   // setter
   void set_layer_idx(int32_t layer_idx) { _layer_idx = layer_idx; }
   void set_layer_name(const std::string& layer_name) { _layer_name = layer_name; }
@@ -43,6 +46,12 @@ class PowerWireSegment
   void set_second_y(int32_t second_y) { _second_y = second_y; }
   void set_width(int32_t width) { _width = width; }
   void set_resistance_per_square(double resistance_per_square) { _resistance_per_square = resistance_per_square; }
+  void set_resistance(double resistance)
+  {
+    _resistance = resistance;
+    _has_explicit_resistance = true;
+  }
+  void set_is_em_checkable(bool is_em_checkable) { _is_em_checkable = is_em_checkable; }
   // function
 
  private:
@@ -54,6 +63,9 @@ class PowerWireSegment
   int32_t _second_y = 0;
   int32_t _width = 0;
   double _resistance_per_square = 0.0;
+  double _resistance = 0.0;
+  bool _has_explicit_resistance = false;
+  bool _is_em_checkable = true;
 };
 
 }  // namespace iemir

--- a/src/operation/iEMIR/source/module/em_analyzer/EMAnalyzer.cpp
+++ b/src/operation/iEMIR/source/module/em_analyzer/EMAnalyzer.cpp
@@ -19,7 +19,52 @@
 #include "DataManager.hpp"
 #include "Logger.hpp"
 #include "Monitor.hpp"
+#include "PowerEdgeType.hpp"
 #include "PowerNode.hpp"
+
+namespace {
+
+std::string normalizeRuleName(const std::string& name)
+{
+  std::string result;
+  for (char ch : name) {
+    if (std::isalnum(static_cast<unsigned char>(ch)) || ch == '_') {
+      result.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));
+    }
+  }
+  return result;
+}
+
+std::vector<std::string> getRuleAliases(const std::string& name)
+{
+  std::vector<std::string> aliases;
+  std::string normalized_name = normalizeRuleName(name);
+  if (normalized_name.empty()) {
+    return aliases;
+  }
+  aliases.push_back(normalized_name);
+  std::smatch match;
+  if (std::regex_match(normalized_name, match, std::regex("^M([0-9]+)$"))) {
+    aliases.push_back("MET" + match.str(1));
+  } else if (std::regex_match(normalized_name, match, std::regex("^MET([0-9]+)$"))) {
+    aliases.push_back("M" + match.str(1));
+  } else if (std::regex_match(normalized_name, match, std::regex("^V([0-9]+)$"))) {
+    aliases.push_back("VIA" + match.str(1));
+  } else if (std::regex_match(normalized_name, match, std::regex("^VIA([0-9]+)$"))) {
+    aliases.push_back("V" + match.str(1));
+  } else if (normalized_name == "TM") {
+    aliases.push_back("T4M2");
+  } else if (normalized_name == "T4M2") {
+    aliases.push_back("TM");
+  } else if (normalized_name == "TV") {
+    aliases.push_back("T4V2");
+  } else if (normalized_name == "T4V2") {
+    aliases.push_back("TV");
+  }
+  return aliases;
+}
+
+}  // namespace
 
 namespace iemir {
 
@@ -102,11 +147,120 @@ void EMAnalyzer::analyzePowerEdge(PowerGraph& power_graph, PowerEdge& power_edge
   PowerNode& second_power_node = power_graph.get_node_list()[power_edge.get_second_node_id()];
   double current = std::abs(first_power_node.get_voltage() - second_power_node.get_voltage()) / power_edge.get_resistance();
   power_edge.set_current(current);
-  power_edge.set_current_density(0.0);
-  power_edge.set_is_violation(false);
+
+  double em_limit = 0.0;
+  std::string em_rule_name;
+  if (!power_edge.get_is_em_checkable()) {
+    em_rule_name = "NON_PHYSICAL_CONNECTOR";
+  } else if (power_edge.get_type() == PowerEdgeType::kWire) {
+    EMMetalRule* metal_rule = getMetalRule(power_edge.get_layer_name());
+    if (metal_rule != nullptr) {
+      em_limit = calcWireEMLimit(power_edge, *metal_rule);
+      em_rule_name = metal_rule->get_name();
+    }
+  } else if (power_edge.get_type() == PowerEdgeType::kVia) {
+    EMViaRule* via_rule = getViaRule(power_edge.get_via_name());
+    if (via_rule != nullptr) {
+      em_limit = calcViaEMLimit(power_edge, *via_rule);
+      em_rule_name = via_rule->get_name();
+    }
+  }
+
+  double em_ratio_percent = em_limit > EMIR_ERROR ? 100.0 * current / em_limit : 0.0;
+  power_edge.set_em_limit(em_limit);
+  power_edge.set_em_ratio_percent(em_ratio_percent);
+  power_edge.set_em_rule_name(em_rule_name);
+  power_edge.set_has_em_limit(em_limit > EMIR_ERROR);
+  power_edge.set_current_density(em_ratio_percent);
+  power_edge.set_is_violation(em_ratio_percent >= EMIRDM.getConfig().em_violation_threshold_percent);
+
   ea_model.set_power_edge_num(ea_model.get_power_edge_num() + 1);
   ea_model.set_total_current(ea_model.get_total_current() + current);
   ea_model.set_max_current(std::max(ea_model.get_max_current(), current));
+}
+
+double EMAnalyzer::getDBUToMicronRatio()
+{
+  int32_t micron_dbu = EMIRDM.getDatabase().get_micron_dbu();
+  if (micron_dbu <= 0) {
+    return 1.0;
+  }
+  return 1.0 / static_cast<double>(micron_dbu);
+}
+
+double EMAnalyzer::getMicronValue(int32_t dbu_value)
+{
+  return static_cast<double>(dbu_value) * getDBUToMicronRatio();
+}
+
+EMMetalRule* EMAnalyzer::getMetalRule(const std::string& layer_name)
+{
+  EMTech& em_tech = EMIRDM.getDatabase().get_em_tech();
+  for (const std::string& alias : getRuleAliases(layer_name)) {
+    auto iter = em_tech.get_metal_rule_map().find(alias);
+    if (iter != em_tech.get_metal_rule_map().end()) {
+      return &iter->second;
+    }
+  }
+  return nullptr;
+}
+
+EMViaRule* EMAnalyzer::getViaRule(const std::string& via_name)
+{
+  EMTech& em_tech = EMIRDM.getDatabase().get_em_tech();
+  std::string normalized_via_name = normalizeRuleName(via_name);
+  for (const std::string& alias : getRuleAliases(via_name)) {
+    auto iter = em_tech.get_via_rule_map().find(alias);
+    if (iter != em_tech.get_via_rule_map().end()) {
+      return &iter->second;
+    }
+  }
+  std::size_t separator_pos = normalized_via_name.find('_');
+  if (separator_pos != std::string::npos) {
+    std::string base_via_name = normalized_via_name.substr(0, separator_pos);
+    for (const std::string& alias : getRuleAliases(base_via_name)) {
+      auto iter = em_tech.get_via_rule_map().find(alias);
+      if (iter != em_tech.get_via_rule_map().end()) {
+        return &iter->second;
+      }
+    }
+  }
+  EMViaRule* best_rule = nullptr;
+  std::size_t best_length = 0;
+  for (std::pair<const std::string, EMViaRule>& rule_pair : em_tech.get_via_rule_map()) {
+    const std::string& rule_name = rule_pair.first;
+    if (normalized_via_name.rfind(rule_name + "_", 0) == 0 && rule_name.size() > best_length) {
+      best_rule = &rule_pair.second;
+      best_length = rule_name.size();
+    }
+  }
+  return best_rule;
+}
+
+std::string EMAnalyzer::getNormalizedRuleName(const std::string& rule_name)
+{
+  return normalizeRuleName(rule_name);
+}
+
+double EMAnalyzer::calcWireEMLimit(PowerEdge& power_edge, EMMetalRule& metal_rule)
+{
+  double width_um = getMicronValue(power_edge.get_width());
+  double effective_width_um = width_um * EMIRDM.getDatabase().get_em_tech().get_half_node_scale_factor() - metal_rule.get_em_adjust_um();
+  if (effective_width_um <= EMIR_ERROR || metal_rule.get_em_limit_ma_per_um() <= 0.0) {
+    return 0.0;
+  }
+  return metal_rule.get_em_limit_ma_per_um() * effective_width_um / 1000.0;
+}
+
+double EMAnalyzer::calcViaEMLimit(PowerEdge& power_edge, EMViaRule& via_rule)
+{
+  if (via_rule.get_em_limit_ma() <= 0.0) {
+    return 0.0;
+  }
+  // A scalar RedHawk VIA EM value is a per-cut limit. Geometry area is not an
+  // interchangeable multiplier unless an area-dependent rule table is present.
+  double scale = power_edge.get_cut_num() > 0 ? static_cast<double>(power_edge.get_cut_num()) : 1.0;
+  return via_rule.get_em_limit_ma() * scale / 1000.0;
 }
 
 }  // namespace iemir

--- a/src/operation/iEMIR/source/module/em_analyzer/EMAnalyzer.hpp
+++ b/src/operation/iEMIR/source/module/em_analyzer/EMAnalyzer.hpp
@@ -18,6 +18,7 @@
 
 #include "Database.hpp"
 #include "EAModel.hpp"
+#include "EMTech.hpp"
 #include "PowerEdge.hpp"
 #include "PowerGraph.hpp"
 
@@ -50,6 +51,13 @@ class EMAnalyzer
   EAModel initEAModel();
   void analyzePowerEdgeList(PowerGraph& power_graph, EAModel& ea_model);
   void analyzePowerEdge(PowerGraph& power_graph, PowerEdge& power_edge, EAModel& ea_model);
+  double getDBUToMicronRatio();
+  double getMicronValue(int32_t dbu_value);
+  EMMetalRule* getMetalRule(const std::string& layer_name);
+  EMViaRule* getViaRule(const std::string& via_name);
+  std::string getNormalizedRuleName(const std::string& rule_name);
+  double calcWireEMLimit(PowerEdge& power_edge, EMMetalRule& metal_rule);
+  double calcViaEMLimit(PowerEdge& power_edge, EMViaRule& via_rule);
 };
 
 }  // namespace iemir

--- a/src/operation/iEMIR/source/module/emir_reporter/EMIRReporter.cpp
+++ b/src/operation/iEMIR/source/module/emir_reporter/EMIRReporter.cpp
@@ -21,9 +21,91 @@
 #include "Logger.hpp"
 #include "Monitor.hpp"
 #include "PowerEdge.hpp"
+#include "PowerEdgeType.hpp"
+#include "PowerNet.hpp"
 #include "PowerNetType.hpp"
 #include "PowerNode.hpp"
+#include "PowerVia.hpp"
+#include "PowerWireSegment.hpp"
 #include "Utility.hpp"
+
+namespace {
+
+struct IRReportRow
+{
+  double severity = 0.0;
+  double voltage = 0.0;
+  double ideal_voltage = 0.0;
+  std::string net_name;
+  double x = 0.0;
+  double y = 0.0;
+  std::string layer_name;
+};
+
+struct EMReportRow
+{
+  bool is_via = false;
+  std::size_t order = 0;
+  std::string object_name;
+  double first_x = 0.0;
+  double first_y = 0.0;
+  double second_x = 0.0;
+  double second_y = 0.0;
+  double em_ratio_percent = 0.0;
+  double em_limit = 0.0;
+  bool has_em_limit = false;
+  double current = 0.0;
+  std::string net_name;
+  double width = 0.0;
+  std::string cut_box;
+  std::string direction;
+  double blech_length = 0.0;
+};
+
+std::string formatFixed(double value, int32_t precision)
+{
+  if (std::abs(value) < 0.5 * std::pow(10.0, -precision)) {
+    value = 0.0;
+  }
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(precision) << value;
+  return oss.str();
+}
+
+std::string formatCompactFixed(double value, int32_t precision)
+{
+  std::string value_text = formatFixed(value, precision);
+  if (value_text.find('.') == std::string::npos) {
+    return value_text;
+  }
+  while (!value_text.empty() && value_text.back() == '0') {
+    value_text.pop_back();
+  }
+  if (!value_text.empty() && value_text.back() == '.') {
+    value_text.pop_back();
+  }
+  if (value_text == "-0") {
+    value_text = "0";
+  }
+  return value_text;
+}
+
+std::string formatScientific(double value, int32_t precision)
+{
+  std::ostringstream oss;
+  oss << std::scientific << std::setprecision(precision) << std::abs(value);
+  return oss.str();
+}
+
+std::string formatPercent(double value)
+{
+  if (std::abs(value) <= 1e-12) {
+    return "0%";
+  }
+  return formatCompactFixed(value, 6) + "%";
+}
+
+}  // namespace
 
 namespace iemir {
 
@@ -62,6 +144,7 @@ void EMIRReporter::report()
   ERModel er_model = initERModel();
   outputIRReport(er_model);
   outputEMReport(er_model);
+  outputResNetworkReport();
 
   EMIRLOG.info(Loc::current(), "Completed", monitor.getStatsInfo());
 }
@@ -90,36 +173,68 @@ void EMIRReporter::buildEMReportFilePath(ERModel& er_model)
 
 void EMIRReporter::outputIRReport(ERModel& er_model)
 {
-  std::ofstream* ir_report_file = EMIRUTIL.getOutputFileStream(er_model.get_ir_report_file_path());
-  outputIRDesignInfo(ir_report_file);
-  outputIRPowerGraphList(ir_report_file);
+  outputIRReportFile(er_model.get_ir_report_file_path());
+  outputIRReportFile(buildDesignReportFilePath(".ir.worst"));
+}
+
+void EMIRReporter::outputIRReportFile(const std::string& report_file_path)
+{
+  std::ofstream* ir_report_file = EMIRUTIL.getOutputFileStream(report_file_path);
+  outputIRReportHeader(ir_report_file);
+  outputIRReportRows(ir_report_file);
   EMIRUTIL.closeFileStream(ir_report_file);
 }
 
-void EMIRReporter::outputIRDesignInfo(std::ofstream* ir_report_file)
+void EMIRReporter::outputIRReportHeader(std::ofstream* ir_report_file)
 {
+  (*ir_report_file) << "# iEMIR RedHawk-compatible static IR report\n";
   (*ir_report_file) << "Design : " << EMIRDM.getDatabase().get_design_name() << "\n\n";
+  (*ir_report_file) << "#Report locations (x, y) with worst voltage_drops/ground_bounces\n";
+  (*ir_report_file) << "#voltage #ideal_volt   #net      #x_y_location     #layer_name\n";
 }
 
-void EMIRReporter::outputIRPowerGraphList(std::ofstream* ir_report_file)
+void EMIRReporter::outputIRReportRows(std::ofstream* ir_report_file)
 {
+  std::vector<IRReportRow> ir_report_row_list;
   for (std::pair<const std::string, PowerGraph>& power_graph_pair : EMIRDM.getDatabase().get_power_graph_map()) {
-    outputIRPowerGraph(ir_report_file, power_graph_pair.second);
+    PowerGraph& power_graph = power_graph_pair.second;
+    double ideal_voltage = power_graph.get_source_voltage();
+    if (power_graph.get_net_type() == PowerNetType::kPower && ideal_voltage <= EMIR_ERROR) {
+      ideal_voltage = getSupplyVoltage(power_graph);
+    }
+    for (PowerNode& power_node : power_graph.get_node_list()) {
+      IRReportRow ir_report_row;
+      ir_report_row.severity = getIRSeverity(power_graph, power_node);
+      ir_report_row.voltage = power_node.get_voltage();
+      ir_report_row.ideal_voltage = ideal_voltage;
+      ir_report_row.net_name = power_graph.get_net_name();
+      ir_report_row.x = getMicronValue(power_node.get_x());
+      ir_report_row.y = getMicronValue(power_node.get_y());
+      ir_report_row.layer_name = getLayerName(power_graph, power_node.get_layer_idx());
+      ir_report_row_list.push_back(ir_report_row);
+    }
   }
-}
-
-void EMIRReporter::outputIRPowerGraph(std::ofstream* ir_report_file, PowerGraph& power_graph)
-{
-  (*ir_report_file) << "########## IR report #################\n";
-  (*ir_report_file) << "Net              : " << power_graph.get_net_name() << "\n";
-  (*ir_report_file) << "Total power      : " << std::scientific << std::setprecision(2) << getTotalPower(power_graph) << " W\n";
-  (*ir_report_file) << "Supply voltage   : " << std::scientific << std::setprecision(2) << getSupplyVoltage(power_graph) << " V\n";
-  (*ir_report_file) << "Worstcase voltage: " << std::scientific << std::setprecision(2) << getWorstVoltage(power_graph) << " V\n";
-  (*ir_report_file) << "Average voltage  : " << std::scientific << std::setprecision(2) << getAverageVoltage(power_graph) << " V\n";
-  (*ir_report_file) << "Average IR drop  : " << std::scientific << std::setprecision(2) << getAverageIRDrop(power_graph) << " V\n";
-  (*ir_report_file) << "Worstcase IR drop: " << std::scientific << std::setprecision(2) << getWorstIRDrop(power_graph) << " V\n";
-  (*ir_report_file) << "Percentage drop  : " << std::fixed << std::setprecision(2) << getPercentageDrop(power_graph) << " %\n";
-  (*ir_report_file) << "######################################\n\n";
+  std::sort(ir_report_row_list.begin(), ir_report_row_list.end(), [](const IRReportRow& lhs, const IRReportRow& rhs) {
+    if (std::abs(lhs.severity - rhs.severity) > 1e-15) {
+      return lhs.severity > rhs.severity;
+    }
+    if (lhs.net_name != rhs.net_name) {
+      return lhs.net_name < rhs.net_name;
+    }
+    if (lhs.layer_name != rhs.layer_name) {
+      return lhs.layer_name < rhs.layer_name;
+    }
+    if (std::abs(lhs.x - rhs.x) > 1e-9) {
+      return lhs.x < rhs.x;
+    }
+    return lhs.y < rhs.y;
+  });
+  for (IRReportRow& ir_report_row : ir_report_row_list) {
+    (*ir_report_file) << std::setw(13) << formatFixed(ir_report_row.voltage, 9) << " " << std::setw(13)
+                      << formatFixed(ir_report_row.ideal_voltage, 9) << " " << std::setw(8) << ir_report_row.net_name << " ("
+                      << std::setw(10) << formatFixed(ir_report_row.x, 3) << "," << std::setw(10) << formatFixed(ir_report_row.y, 3)
+                      << ")  " << ir_report_row.layer_name << "\n";
+  }
 }
 
 double EMIRReporter::getTotalPower(PowerGraph& power_graph)
@@ -230,39 +345,187 @@ double EMIRReporter::getPercentageDrop(PowerGraph& power_graph)
 
 void EMIRReporter::outputEMReport(ERModel& er_model)
 {
-  std::ofstream* em_report_file = EMIRUTIL.getOutputFileStream(er_model.get_em_report_file_path());
-  outputEMDesignInfo(em_report_file);
-  outputEMPowerGraphList(em_report_file);
+  outputEMReportFile(er_model.get_em_report_file_path(), false);
+  outputEMReportFile(buildDesignReportFilePath(".em"), false);
+  outputEMReportFile(buildDesignReportFilePath(".em.worst"), true);
+}
+
+void EMIRReporter::outputEMReportFile(const std::string& report_file_path, bool worst_only)
+{
+  std::ofstream* em_report_file = EMIRUTIL.getOutputFileStream(report_file_path);
+  outputEMReportHeader(em_report_file, worst_only);
+  outputEMReportRows(em_report_file, worst_only);
   EMIRUTIL.closeFileStream(em_report_file);
 }
 
-void EMIRReporter::outputEMDesignInfo(std::ofstream* em_report_file)
+void EMIRReporter::outputEMReportHeader(std::ofstream* em_report_file, bool worst_only)
 {
+  (*em_report_file) << "# iEMIR RedHawk-compatible static EM/current report\n";
   (*em_report_file) << "Design : " << EMIRDM.getDatabase().get_design_name() << "\n\n";
-}
-
-void EMIRReporter::outputEMPowerGraphList(std::ofstream* em_report_file)
-{
-  for (std::pair<const std::string, PowerGraph>& power_graph_pair : EMIRDM.getDatabase().get_power_graph_map()) {
-    outputEMPowerGraph(em_report_file, power_graph_pair.second);
+  (*em_report_file) << "# EM MODE is AVG\n";
+  if (worst_only) {
+    (*em_report_file)
+        << "# This file reports EM/current rows in decreasing order. Unit used for coordinates and dimensions is um.\n\n";
+    (*em_report_file) << "# For wires: #layer #end-to-end_coordinates #EM_Ratio #net #width #blech_length #current\n";
+    (*em_report_file) << "# For vias: #via_name #x-y_coordinates #EM_Ratio #current #net #cut_box #direction #blech_length\n\n";
+  } else {
+    (*em_report_file) << "# This file reports the EM values and currents. Unit used for coordinates and dimensions is um.\n";
+    (*em_report_file) << "# EM_Ratio is calculated from solved current and loaded RedHawk EM limits when available.\n\n";
+    (*em_report_file) << "# For wires: #layer #end-to-end_coordinates #EM_Ratio #Current_value #net #width #blech_length\n";
+    (*em_report_file) << "# For vias:  #via_name #x-y_coordinates #EM_Ratio #Current_value #net #via_cut_bounding_box #Direction #blech_length\n\n";
   }
 }
 
-void EMIRReporter::outputEMPowerGraph(std::ofstream* em_report_file, PowerGraph& power_graph)
+void EMIRReporter::outputEMReportRows(std::ofstream* em_report_file, bool worst_only)
 {
-  (*em_report_file) << "########## EM analysis ###############\n";
-  (*em_report_file) << "Net                : " << power_graph.get_net_name() << "\n";
-  (*em_report_file) << "Maximum current    : " << std::scientific << std::setprecision(2) << getMaxCurrent(power_graph) << " A\n";
-  (*em_report_file) << "Average current    : " << std::scientific << std::setprecision(2) << getAverageCurrent(power_graph) << " A\n";
-  (*em_report_file) << "Number of resistors: " << power_graph.get_edge_list().size() << "\n";
-  (*em_report_file) << "######################################\n\n";
+  std::vector<EMReportRow> em_report_row_list;
+  std::size_t order = 0;
+  for (std::pair<const std::string, PowerGraph>& power_graph_pair : EMIRDM.getDatabase().get_power_graph_map()) {
+    PowerGraph& power_graph = power_graph_pair.second;
+    for (PowerEdge& power_edge : power_graph.get_edge_list()) {
+      if (!power_edge.get_is_em_checkable()) {
+        continue;
+      }
+      if (power_edge.get_first_node_id() >= power_graph.get_node_list().size()
+          || power_edge.get_second_node_id() >= power_graph.get_node_list().size()) {
+        continue;
+      }
+      PowerNode& first_power_node = power_graph.get_node_list()[power_edge.get_first_node_id()];
+      PowerNode& second_power_node = power_graph.get_node_list()[power_edge.get_second_node_id()];
+      EMReportRow em_report_row;
+      em_report_row.order = order++;
+      em_report_row.is_via = power_edge.get_type() == PowerEdgeType::kVia;
+      em_report_row.object_name = em_report_row.is_via ? getViaName(power_graph, power_edge)
+                                                       : (power_edge.get_layer_name().empty() ? getLayerName(power_graph, power_edge.get_layer_idx())
+                                                                                              : power_edge.get_layer_name());
+      em_report_row.first_x = getMicronValue(first_power_node.get_x());
+      em_report_row.first_y = getMicronValue(first_power_node.get_y());
+      em_report_row.second_x = getMicronValue(second_power_node.get_x());
+      em_report_row.second_y = getMicronValue(second_power_node.get_y());
+      if (em_report_row.is_via) {
+        auto [x, y] = getViaLocation(power_graph, power_edge);
+        em_report_row.first_x = em_report_row.second_x = x;
+        em_report_row.first_y = em_report_row.second_y = y;
+      }
+      em_report_row.em_ratio_percent = getEMRatioPercent(power_edge);
+      em_report_row.em_limit = power_edge.get_em_limit();
+      em_report_row.has_em_limit = power_edge.get_has_em_limit();
+      em_report_row.current = std::abs(power_edge.get_current());
+      em_report_row.net_name = power_graph.get_net_name();
+      em_report_row.width = getMicronValue(power_edge.get_width());
+      em_report_row.cut_box = getViaCutBox(power_graph, power_edge);
+      em_report_row.direction = getViaDirection(power_graph, power_edge);
+      em_report_row_list.push_back(em_report_row);
+    }
+  }
+  if (worst_only) {
+    std::sort(em_report_row_list.begin(), em_report_row_list.end(), [](const EMReportRow& lhs, const EMReportRow& rhs) {
+      if (std::abs(lhs.em_ratio_percent - rhs.em_ratio_percent) > 1e-15) {
+        return lhs.em_ratio_percent > rhs.em_ratio_percent;
+      }
+      if (std::abs(lhs.current - rhs.current) > 1e-18) {
+        return lhs.current > rhs.current;
+      }
+      return lhs.order < rhs.order;
+    });
+  }
+  for (EMReportRow& em_report_row : em_report_row_list) {
+    if (em_report_row.is_via) {
+      double x = em_report_row.first_x;
+      double y = em_report_row.first_y;
+      (*em_report_file) << "via " << em_report_row.object_name << "  (" << formatFixed(x, 3) << "," << formatFixed(y, 3) << ")\t"
+                        << formatPercent(em_report_row.em_ratio_percent) << " " << formatScientific(em_report_row.current, 6) << " "
+                        << em_report_row.net_name << "  " << em_report_row.cut_box << " " << em_report_row.direction << "  "
+                        << formatFixed(em_report_row.blech_length, 3) << "\n";
+      continue;
+    }
+    (*em_report_file) << em_report_row.object_name << "  (" << formatFixed(em_report_row.first_x, 3) << "," << formatFixed(em_report_row.first_y, 3)
+                      << " " << formatFixed(em_report_row.second_x, 3) << "," << formatFixed(em_report_row.second_y, 3) << ")\t"
+                      << formatPercent(em_report_row.em_ratio_percent);
+    if (worst_only) {
+      (*em_report_file) << "  " << em_report_row.net_name << "  " << formatCompactFixed(em_report_row.width, 6) << "  "
+                        << formatFixed(em_report_row.blech_length, 3) << "  " << formatScientific(em_report_row.current, 6) << "\n";
+    } else {
+      (*em_report_file) << "\t" << formatScientific(em_report_row.current, 6) << "  " << em_report_row.net_name << "  "
+                        << formatCompactFixed(em_report_row.width, 6) << "  " << formatFixed(em_report_row.blech_length, 3) << "\n";
+    }
+  }
+}
+
+void EMIRReporter::outputResNetworkReport()
+{
+  outputResNetworkReportFile(buildDesignReportFilePath(".res_network"));
+  outputResNetworkReportFile(EMIRUTIL.getString(EMIRDM.getConfig().er_temp_directory_path, "res_network.rpt"));
+}
+
+void EMIRReporter::outputResNetworkReportFile(const std::string& report_file_path)
+{
+  std::ofstream* res_network_report_file = EMIRUTIL.getOutputFileStream(report_file_path);
+  outputResNetworkReportHeader(res_network_report_file);
+  outputResNetworkReportRows(res_network_report_file);
+  EMIRUTIL.closeFileStream(res_network_report_file);
+}
+
+void EMIRReporter::outputResNetworkReportHeader(std::ofstream* res_network_report_file)
+{
+  (*res_network_report_file) << "# iEMIR RedHawk-compatible resistance/current/EM network report\n";
+  (*res_network_report_file) << "Design : " << EMIRDM.getDatabase().get_design_name() << "\n\n";
+  (*res_network_report_file) << "# For Wire-segments\n";
+  (*res_network_report_file)
+      << "# <ID> <layer> <net> <start(x y) end(x y) (um)> <direction(l|r|u|d)> <current(A)> <em_limit(A)> <em(%)> <resistance(ohm)> "
+         "<width(um)> <rule-name>\n";
+  (*res_network_report_file) << "# For Vias\n";
+  (*res_network_report_file)
+      << "# <ID> <layer> <via_name> <net> <coord(x y) (um)> <cut_#> <cut_area(um^2)> <resistance(ohm)> <current_dir(u|d)> "
+         "<current(A)> <em_limit(A)> <em%> <rule-name>\n\n";
+}
+
+void EMIRReporter::outputResNetworkReportRows(std::ofstream* res_network_report_file)
+{
+  for (std::pair<const std::string, PowerGraph>& power_graph_pair : EMIRDM.getDatabase().get_power_graph_map()) {
+    PowerGraph& power_graph = power_graph_pair.second;
+    for (PowerEdge& power_edge : power_graph.get_edge_list()) {
+      if (power_edge.get_first_node_id() >= power_graph.get_node_list().size()
+          || power_edge.get_second_node_id() >= power_graph.get_node_list().size()) {
+        continue;
+      }
+      PowerNode& first_power_node = power_graph.get_node_list()[power_edge.get_first_node_id()];
+      PowerNode& second_power_node = power_graph.get_node_list()[power_edge.get_second_node_id()];
+      if (power_edge.get_type() == PowerEdgeType::kWire) {
+        std::string layer_name = power_edge.get_layer_name().empty() ? getLayerName(power_graph, power_edge.get_layer_idx()) : power_edge.get_layer_name();
+        (*res_network_report_file)
+            << power_edge.get_edge_id() << " " << layer_name << " " << power_graph.get_net_name() << " (" << formatFixed(getMicronValue(first_power_node.get_x()), 3)
+            << " " << formatFixed(getMicronValue(first_power_node.get_y()), 3) << ") (" << formatFixed(getMicronValue(second_power_node.get_x()), 3)
+            << " " << formatFixed(getMicronValue(second_power_node.get_y()), 3) << ") " << getWireDirection(power_graph, power_edge) << " "
+            << formatScientific(power_edge.get_current(), 6) << " " << formatScientific(power_edge.get_em_limit(), 6) << " "
+            << formatCompactFixed(power_edge.get_em_ratio_percent(), 6) << " " << formatScientific(power_edge.get_resistance(), 6) << " "
+            << formatCompactFixed(getMicronValue(power_edge.get_width()), 6) << " "
+            << (power_edge.get_em_rule_name().empty() ? "NA" : power_edge.get_em_rule_name()) << "\n";
+      } else if (power_edge.get_type() == PowerEdgeType::kVia) {
+        auto [x, y] = getViaLocation(power_graph, power_edge);
+        std::string via_rule_name = power_edge.get_em_rule_name().empty() ? getViaName(power_graph, power_edge) : power_edge.get_em_rule_name();
+        std::string direction = getViaDirection(power_graph, power_edge);
+        if (direction == "UP") {
+          direction = "u";
+        } else if (direction == "DN") {
+          direction = "d";
+        }
+        (*res_network_report_file)
+            << power_edge.get_edge_id() << " " << via_rule_name << " " << getViaName(power_graph, power_edge) << " " << power_graph.get_net_name()
+            << " (" << formatFixed(x, 3) << " " << formatFixed(y, 3) << ") " << power_edge.get_cut_num() << " "
+            << formatCompactFixed(power_edge.get_cut_area_um2(), 9) << " " << formatScientific(power_edge.get_resistance(), 6) << " "
+            << direction << " " << formatScientific(power_edge.get_current(), 6) << " " << formatScientific(power_edge.get_em_limit(), 6) << " "
+            << formatCompactFixed(power_edge.get_em_ratio_percent(), 6) << " " << via_rule_name << "\n";
+      }
+    }
+  }
 }
 
 double EMIRReporter::getMaxCurrent(PowerGraph& power_graph)
 {
   double max_current = 0.0;
   for (PowerEdge& power_edge : power_graph.get_edge_list()) {
-    max_current = std::max(max_current, power_edge.get_current());
+    max_current = std::max(max_current, std::abs(power_edge.get_current()));
   }
   return max_current;
 }
@@ -274,9 +537,179 @@ double EMIRReporter::getAverageCurrent(PowerGraph& power_graph)
   }
   double total_current = 0.0;
   for (PowerEdge& power_edge : power_graph.get_edge_list()) {
-    total_current += power_edge.get_current();
+    total_current += std::abs(power_edge.get_current());
   }
   return total_current / power_graph.get_edge_list().size();
+}
+
+std::string EMIRReporter::buildDesignReportFilePath(const std::string& suffix)
+{
+  return EMIRUTIL.getString(EMIRDM.getConfig().er_temp_directory_path, EMIRDM.getDatabase().get_design_name(), suffix);
+}
+
+PowerVia* EMIRReporter::getPowerVia(PowerGraph& power_graph, PowerEdge& power_edge)
+{
+  if (power_edge.get_type() != PowerEdgeType::kVia || power_edge.get_first_node_id() >= power_graph.get_node_list().size()
+      || power_edge.get_second_node_id() >= power_graph.get_node_list().size()) {
+    return nullptr;
+  }
+  Database& database = EMIRDM.getDatabase();
+  auto power_net_iter = database.get_power_net_map().find(power_graph.get_net_name());
+  if (power_net_iter == database.get_power_net_map().end()) {
+    return nullptr;
+  }
+  PowerNode& first_power_node = power_graph.get_node_list()[power_edge.get_first_node_id()];
+  PowerNode& second_power_node = power_graph.get_node_list()[power_edge.get_second_node_id()];
+  int32_t bottom_layer_idx = std::min(first_power_node.get_layer_idx(), second_power_node.get_layer_idx());
+  int32_t top_layer_idx = std::max(first_power_node.get_layer_idx(), second_power_node.get_layer_idx());
+  PowerNode& bottom_power_node = first_power_node.get_layer_idx() == bottom_layer_idx ? first_power_node : second_power_node;
+  PowerNode& top_power_node = first_power_node.get_layer_idx() == top_layer_idx ? first_power_node : second_power_node;
+  for (PowerVia& power_via : power_net_iter->second.get_via_list()) {
+    if (power_via.get_bottom_layer_idx() == bottom_layer_idx && power_via.get_top_layer_idx() == top_layer_idx
+        && power_via.get_bottom_x() == bottom_power_node.get_x() && power_via.get_bottom_y() == bottom_power_node.get_y()
+        && power_via.get_top_x() == top_power_node.get_x() && power_via.get_top_y() == top_power_node.get_y()) {
+      return &power_via;
+    }
+  }
+  return nullptr;
+}
+
+std::pair<double, double> EMIRReporter::getViaLocation(PowerGraph& power_graph, PowerEdge& power_edge)
+{
+  // Electrical landing points can move to a connected wire junction. Reports
+  // identify the physical via by its original location, without moving nodes.
+  if (PowerVia* power_via = getPowerVia(power_graph, power_edge); power_via != nullptr) {
+    return {getMicronValue(power_via->get_x()), getMicronValue(power_via->get_y())};
+  }
+  // Graphs constructed without physical via data retain the endpoint fallback.
+  PowerNode& first = power_graph.get_node_list()[power_edge.get_first_node_id()];
+  PowerNode& second = power_graph.get_node_list()[power_edge.get_second_node_id()];
+  return {(getMicronValue(first.get_x()) + getMicronValue(second.get_x())) / 2.0,
+          (getMicronValue(first.get_y()) + getMicronValue(second.get_y())) / 2.0};
+}
+
+std::string EMIRReporter::getLayerName(PowerGraph& power_graph, int32_t layer_idx)
+{
+  Database& database = EMIRDM.getDatabase();
+  auto power_net_iter = database.get_power_net_map().find(power_graph.get_net_name());
+  if (power_net_iter != database.get_power_net_map().end()) {
+    for (PowerWireSegment& power_wire_segment : power_net_iter->second.get_wire_segment_list()) {
+      if (power_wire_segment.get_layer_idx() == layer_idx && !power_wire_segment.get_layer_name().empty()) {
+        return power_wire_segment.get_layer_name();
+      }
+    }
+    for (PowerVia& power_via : power_net_iter->second.get_via_list()) {
+      if (power_via.get_bottom_layer_idx() == layer_idx && !power_via.get_bottom_layer_name().empty()) {
+        return power_via.get_bottom_layer_name();
+      }
+      if (power_via.get_top_layer_idx() == layer_idx && !power_via.get_top_layer_name().empty()) {
+        return power_via.get_top_layer_name();
+      }
+    }
+  }
+  return EMIRUTIL.getString("LAYER", layer_idx);
+}
+
+std::string EMIRReporter::getViaName(PowerGraph& power_graph, PowerEdge& power_edge)
+{
+  if (!power_edge.get_via_name().empty()) {
+    return power_edge.get_via_name();
+  }
+  PowerVia* power_via = getPowerVia(power_graph, power_edge);
+  if (power_via != nullptr && !power_via->get_via_name().empty()) {
+    return power_via->get_via_name();
+  }
+  if (power_edge.get_first_node_id() >= power_graph.get_node_list().size() || power_edge.get_second_node_id() >= power_graph.get_node_list().size()) {
+    return "VIA_UNKNOWN";
+  }
+  PowerNode& first_power_node = power_graph.get_node_list()[power_edge.get_first_node_id()];
+  PowerNode& second_power_node = power_graph.get_node_list()[power_edge.get_second_node_id()];
+  int32_t bottom_layer_idx = std::min(first_power_node.get_layer_idx(), second_power_node.get_layer_idx());
+  int32_t top_layer_idx = std::max(first_power_node.get_layer_idx(), second_power_node.get_layer_idx());
+  return EMIRUTIL.getString("VIA_", getLayerName(power_graph, bottom_layer_idx), "_", getLayerName(power_graph, top_layer_idx));
+}
+
+std::string EMIRReporter::getViaCutBox(PowerGraph& power_graph, PowerEdge& power_edge)
+{
+  if (power_edge.get_cut_low_x() != 0 || power_edge.get_cut_low_y() != 0 || power_edge.get_cut_high_x() != 0 || power_edge.get_cut_high_y() != 0) {
+    return EMIRUTIL.getString(formatFixed(getMicronValue(power_edge.get_cut_low_x()), 3), " ",
+                              formatFixed(getMicronValue(power_edge.get_cut_low_y()), 3), " ",
+                              formatFixed(getMicronValue(power_edge.get_cut_high_x()), 3), " ",
+                              formatFixed(getMicronValue(power_edge.get_cut_high_y()), 3));
+  }
+  PowerVia* power_via = getPowerVia(power_graph, power_edge);
+  if (power_via == nullptr) {
+    return "0.000 0.000 0.000 0.000";
+  }
+  return EMIRUTIL.getString(formatFixed(getMicronValue(power_via->get_cut_low_x()), 3), " ",
+                            formatFixed(getMicronValue(power_via->get_cut_low_y()), 3), " ",
+                            formatFixed(getMicronValue(power_via->get_cut_high_x()), 3), " ",
+                            formatFixed(getMicronValue(power_via->get_cut_high_y()), 3));
+}
+
+std::string EMIRReporter::getViaDirection(PowerGraph& power_graph, PowerEdge& power_edge)
+{
+  if (power_edge.get_first_node_id() >= power_graph.get_node_list().size() || power_edge.get_second_node_id() >= power_graph.get_node_list().size()) {
+    return "NA";
+  }
+  PowerNode& first_power_node = power_graph.get_node_list()[power_edge.get_first_node_id()];
+  PowerNode& second_power_node = power_graph.get_node_list()[power_edge.get_second_node_id()];
+  bool current_from_first = first_power_node.get_voltage() >= second_power_node.get_voltage();
+  int32_t from_layer_idx = current_from_first ? first_power_node.get_layer_idx() : second_power_node.get_layer_idx();
+  int32_t to_layer_idx = current_from_first ? second_power_node.get_layer_idx() : first_power_node.get_layer_idx();
+  if (to_layer_idx > from_layer_idx) {
+    return "UP";
+  }
+  if (to_layer_idx < from_layer_idx) {
+    return "DN";
+  }
+  return "NA";
+}
+
+std::string EMIRReporter::getWireDirection(PowerGraph& power_graph, PowerEdge& power_edge)
+{
+  if (power_edge.get_first_node_id() >= power_graph.get_node_list().size() || power_edge.get_second_node_id() >= power_graph.get_node_list().size()) {
+    return "n";
+  }
+  PowerNode& first_power_node = power_graph.get_node_list()[power_edge.get_first_node_id()];
+  PowerNode& second_power_node = power_graph.get_node_list()[power_edge.get_second_node_id()];
+  bool current_from_first = first_power_node.get_voltage() >= second_power_node.get_voltage();
+  PowerNode& from_node = current_from_first ? first_power_node : second_power_node;
+  PowerNode& to_node = current_from_first ? second_power_node : first_power_node;
+  if (std::abs(from_node.get_x() - to_node.get_x()) >= std::abs(from_node.get_y() - to_node.get_y())) {
+    return to_node.get_x() >= from_node.get_x() ? "r" : "l";
+  }
+  return to_node.get_y() >= from_node.get_y() ? "u" : "d";
+}
+
+double EMIRReporter::getDBUToMicronRatio()
+{
+  int32_t micron_dbu = EMIRDM.getDatabase().get_micron_dbu();
+  if (micron_dbu <= 0) {
+    return 1.0;
+  }
+  return 1.0 / static_cast<double>(micron_dbu);
+}
+
+double EMIRReporter::getMicronValue(int32_t dbu_value)
+{
+  return static_cast<double>(dbu_value) * getDBUToMicronRatio();
+}
+
+double EMIRReporter::getIRSeverity(PowerGraph& power_graph, PowerNode& power_node)
+{
+  if (power_graph.get_net_type() == PowerNetType::kGround) {
+    return std::abs(power_node.get_voltage() - power_graph.get_source_voltage());
+  }
+  return std::abs(power_graph.get_source_voltage() - power_node.get_voltage());
+}
+
+double EMIRReporter::getEMRatioPercent(PowerEdge& power_edge)
+{
+  if (power_edge.get_em_ratio_percent() <= 0.0) {
+    return 0.0;
+  }
+  return power_edge.get_em_ratio_percent();
 }
 
 }  // namespace iemir

--- a/src/operation/iEMIR/source/module/emir_reporter/EMIRReporter.hpp
+++ b/src/operation/iEMIR/source/module/emir_reporter/EMIRReporter.hpp
@@ -19,6 +19,7 @@
 #include "Database.hpp"
 #include "ERModel.hpp"
 #include "PowerGraph.hpp"
+#include "PowerVia.hpp"
 
 namespace iemir {
 
@@ -48,9 +49,9 @@ class EMIRReporter
   void buildIRReportFilePath(ERModel& er_model);
   void buildEMReportFilePath(ERModel& er_model);
   void outputIRReport(ERModel& er_model);
-  void outputIRDesignInfo(std::ofstream* ir_report_file);
-  void outputIRPowerGraphList(std::ofstream* ir_report_file);
-  void outputIRPowerGraph(std::ofstream* ir_report_file, PowerGraph& power_graph);
+  void outputIRReportFile(const std::string& report_file_path);
+  void outputIRReportHeader(std::ofstream* ir_report_file);
+  void outputIRReportRows(std::ofstream* ir_report_file);
   double getTotalPower(PowerGraph& power_graph);
   double getSupplyVoltage(PowerGraph& power_graph);
   int32_t getInstancePowerGraphNum(uint64_t instance_id, PowerNetType power_net_type);
@@ -60,11 +61,27 @@ class EMIRReporter
   double getAverageIRDrop(PowerGraph& power_graph);
   double getPercentageDrop(PowerGraph& power_graph);
   void outputEMReport(ERModel& er_model);
-  void outputEMDesignInfo(std::ofstream* em_report_file);
-  void outputEMPowerGraphList(std::ofstream* em_report_file);
-  void outputEMPowerGraph(std::ofstream* em_report_file, PowerGraph& power_graph);
+  void outputEMReportFile(const std::string& report_file_path, bool worst_only);
+  void outputEMReportHeader(std::ofstream* em_report_file, bool worst_only);
+  void outputEMReportRows(std::ofstream* em_report_file, bool worst_only);
+  void outputResNetworkReport();
+  void outputResNetworkReportFile(const std::string& report_file_path);
+  void outputResNetworkReportHeader(std::ofstream* res_network_report_file);
+  void outputResNetworkReportRows(std::ofstream* res_network_report_file);
   double getMaxCurrent(PowerGraph& power_graph);
   double getAverageCurrent(PowerGraph& power_graph);
+  std::string buildDesignReportFilePath(const std::string& suffix);
+  PowerVia* getPowerVia(PowerGraph& power_graph, PowerEdge& power_edge);
+  std::pair<double, double> getViaLocation(PowerGraph& power_graph, PowerEdge& power_edge);
+  std::string getLayerName(PowerGraph& power_graph, int32_t layer_idx);
+  std::string getViaName(PowerGraph& power_graph, PowerEdge& power_edge);
+  std::string getViaCutBox(PowerGraph& power_graph, PowerEdge& power_edge);
+  std::string getViaDirection(PowerGraph& power_graph, PowerEdge& power_edge);
+  std::string getWireDirection(PowerGraph& power_graph, PowerEdge& power_edge);
+  double getDBUToMicronRatio();
+  double getMicronValue(int32_t dbu_value);
+  double getIRSeverity(PowerGraph& power_graph, PowerNode& power_node);
+  double getEMRatioPercent(PowerEdge& power_edge);
 };
 
 }  // namespace iemir

--- a/src/operation/iEMIR/source/module/graph_builder/GraphBuilder.cpp
+++ b/src/operation/iEMIR/source/module/graph_builder/GraphBuilder.cpp
@@ -25,6 +25,7 @@
 #include "PowerNode.hpp"
 #include "PowerNodeType.hpp"
 #include "PowerPin.hpp"
+#include "PowerSource.hpp"
 #include "PowerVia.hpp"
 #include "PowerWireSegment.hpp"
 
@@ -82,6 +83,20 @@ void GraphBuilder::buildPowerGraphList()
   Database& database = EMIRDM.getDatabase();
   database.get_power_graph_map().clear();
   for (std::pair<const std::string, PowerNet>& power_net_pair : database.get_power_net_map()) {
+    if (!database.get_power_source_list().empty()) {
+      bool has_source = false;
+      for (PowerSource& source : database.get_power_source_list()) {
+        if (source.get_net_type() == power_net_pair.second.get_type()
+            && (source.get_net_name().empty() || source.get_net_name() == power_net_pair.first)) {
+          has_source = true;
+          break;
+        }
+      }
+      if (!has_source) {
+        EMIRLOG.info(Loc::current(), "Skipping PG net without a configured PLOC source: ", power_net_pair.first);
+        continue;
+      }
+    }
     buildPowerGraph(power_net_pair.second);
   }
 }
@@ -92,10 +107,12 @@ void GraphBuilder::buildPowerGraph(PowerNet& power_net)
   GBModel gb_model = initGBModel();
   initPowerGraph(power_graph, power_net);
   buildWireNodeList(power_graph, power_net, gb_model);
-  buildWireIntersectionNodeList(power_graph, power_net, gb_model);
+  if (!power_net.get_has_explicit_parasitics()) {
+    buildWireIntersectionNodeList(power_graph, power_net, gb_model);
+  }
   buildViaNodeList(power_graph, power_net, gb_model);
+  buildConfiguredSourceNodeList(power_graph, power_net, gb_model);
   buildPinNodeList(power_graph, power_net, gb_model);
-  buildGeneratedSourceNodeList(power_graph);
   buildWireEdgeList(power_graph, power_net, gb_model);
   buildViaEdgeList(power_graph, power_net);
   checkPowerGraphConnectivity(power_graph);
@@ -129,8 +146,10 @@ void GraphBuilder::buildWireEndpointNode(PowerGraph& power_graph, PowerWireSegme
 std::size_t GraphBuilder::getPowerNode(PowerGraph& power_graph, int32_t layer_idx, int32_t x, int32_t y, PowerNodeType power_node_type)
 {
   std::vector<PowerNode>& power_node_list = power_graph.get_node_list();
-  for (PowerNode& power_node : power_node_list) {
-    if (power_node.get_layer_idx() == layer_idx && power_node.get_x() == x && power_node.get_y() == y) {
+  auto coordinate = std::make_tuple(layer_idx, x, y);
+  auto node_iter = power_graph.get_coordinate_node_id_map().find(coordinate);
+  if (node_iter != power_graph.get_coordinate_node_id_map().end()) {
+      PowerNode& power_node = power_node_list[node_iter->second];
       if (power_node_type == PowerNodeType::kSource) {
         power_node.set_type(PowerNodeType::kSource);
         power_node.set_is_source(true);
@@ -138,7 +157,6 @@ std::size_t GraphBuilder::getPowerNode(PowerGraph& power_graph, int32_t layer_id
         power_node.set_type(power_node_type);
       }
       return power_node.get_node_id();
-    }
   }
   PowerNode power_node;
   power_node.set_node_id(power_node_list.size());
@@ -148,6 +166,7 @@ std::size_t GraphBuilder::getPowerNode(PowerGraph& power_graph, int32_t layer_id
   power_node.set_y(y);
   power_node.set_is_source(power_node_type == PowerNodeType::kSource);
   power_node_list.push_back(power_node);
+  power_graph.get_coordinate_node_id_map()[coordinate] = power_node.get_node_id();
   return power_node.get_node_id();
 }
 
@@ -237,8 +256,13 @@ void GraphBuilder::appendWireNodeId(GBModel& gb_model, std::size_t segment_idx, 
 void GraphBuilder::buildViaNodeList(PowerGraph& power_graph, PowerNet& power_net, GBModel& gb_model)
 {
   for (PowerVia& power_via : power_net.get_via_list()) {
-    std::size_t bottom_node_id = getPowerNode(power_graph, power_via.get_bottom_layer_idx(), power_via.get_x(), power_via.get_y(), PowerNodeType::kVia);
-    std::size_t top_node_id = getPowerNode(power_graph, power_via.get_top_layer_idx(), power_via.get_x(), power_via.get_y(), PowerNodeType::kVia);
+    std::size_t bottom_node_id = getPowerNode(power_graph, power_via.get_bottom_layer_idx(), power_via.get_bottom_x(), power_via.get_bottom_y(),
+                                              PowerNodeType::kVia);
+    std::size_t top_node_id
+        = getPowerNode(power_graph, power_via.get_top_layer_idx(), power_via.get_top_x(), power_via.get_top_y(), PowerNodeType::kVia);
+    if (power_net.get_has_explicit_parasitics()) {
+      continue;
+    }
     for (std::size_t segment_idx = 0; segment_idx < power_net.get_wire_segment_list().size(); segment_idx++) {
       PowerWireSegment& power_wire_segment = power_net.get_wire_segment_list()[segment_idx];
       if (power_wire_segment.get_layer_idx() == power_via.get_bottom_layer_idx()
@@ -255,52 +279,168 @@ void GraphBuilder::buildViaNodeList(PowerGraph& power_graph, PowerNet& power_net
 
 void GraphBuilder::buildPinNodeList(PowerGraph& power_graph, PowerNet& power_net, GBModel& gb_model)
 {
+  std::size_t connected_pin_num = 0;
+  std::size_t skipped_pin_num = 0;
   for (PowerPin& power_pin : power_net.get_pin_list()) {
     PowerNodeType power_node_type = power_pin.get_is_source() ? PowerNodeType::kSource : PowerNodeType::kInstancePin;
-    std::size_t node_id = getPowerNode(power_graph, power_pin.get_layer_idx(), power_pin.get_x(), power_pin.get_y(), power_node_type);
-    PowerNode& power_node = power_graph.get_node_list()[node_id];
-    if (power_pin.get_is_source()) {
-      std::vector<std::size_t>& source_node_id_list = power_graph.get_source_node_id_list();
-      if (std::find(source_node_id_list.begin(), source_node_id_list.end(), node_id) == source_node_id_list.end()) {
-        source_node_id_list.push_back(node_id);
+    std::set<std::size_t> pin_node_id_set;
+    std::map<std::size_t, double> pin_node_weights;
+    bool use_imported_pin_area = power_net.get_has_explicit_parasitics() && !power_pin.get_is_source();
+    if (use_imported_pin_area) {
+      // Reconstruct the distributed load on the imported extraction nodes.
+      // A segment wholly within the pin contributes half its length at each
+      // endpoint. Use the original segments, so later pin subdivisions cannot
+      // change another pin's current distribution or make it order dependent.
+      auto inside_pin = [&power_pin](int32_t x, int32_t y) {
+        return power_pin.get_low_x() <= x && x <= power_pin.get_high_x() && power_pin.get_low_y() <= y && y <= power_pin.get_high_y();
+      };
+      for (PowerWireSegment& segment : power_net.get_wire_segment_list()) {
+        if (segment.get_layer_idx() != power_pin.get_layer_idx()) {
+          continue;
+        }
+        bool first_inside = inside_pin(segment.get_first_x(), segment.get_first_y());
+        bool second_inside = inside_pin(segment.get_second_x(), segment.get_second_y());
+        std::size_t first_id = 0;
+        std::size_t second_id = 0;
+        if (first_inside) {
+          first_id = getPowerNode(power_graph, power_pin.get_layer_idx(), segment.get_first_x(), segment.get_first_y(), power_node_type);
+          pin_node_id_set.insert(first_id);
+        }
+        if (second_inside) {
+          second_id = getPowerNode(power_graph, power_pin.get_layer_idx(), segment.get_second_x(), segment.get_second_y(), power_node_type);
+          pin_node_id_set.insert(second_id);
+        }
+        if (first_inside && second_inside) {
+          double length = std::abs(static_cast<double>(segment.get_second_x()) - segment.get_first_x())
+                          + std::abs(static_cast<double>(segment.get_second_y()) - segment.get_first_y());
+          pin_node_weights[first_id] += length / 2.0;
+          pin_node_weights[second_id] += length / 2.0;
+        }
       }
-    } else {
+    }
+    if (!use_imported_pin_area || pin_node_id_set.empty()) {
+      for (std::size_t segment_idx = 0; segment_idx < power_net.get_wire_segment_list().size(); segment_idx++) {
+        PowerWireSegment& power_wire_segment = power_net.get_wire_segment_list()[segment_idx];
+        int32_t x = 0;
+        int32_t y = 0;
+        if (power_wire_segment.get_layer_idx() == power_pin.get_layer_idx()
+            && getPinWireConnectionCoordinate(power_wire_segment, power_pin, x, y)) {
+          std::size_t node_id = getPowerNode(power_graph, power_pin.get_layer_idx(), x, y, power_node_type);
+          appendWireNodeId(gb_model, segment_idx, node_id);
+          pin_node_id_set.insert(node_id);
+        }
+      }
+    }
+    if (pin_node_id_set.empty()) {
+      skipped_pin_num++;
+      continue;
+    }
+    connected_pin_num++;
+    double total_weight = 0.0;
+    for (const auto& [node_id, weight] : pin_node_weights) {
+      total_weight += weight;
+    }
+    for (std::size_t node_id : pin_node_id_set) {
+      PowerNode& power_node = power_graph.get_node_list()[node_id];
+      if (power_pin.get_is_source()) {
+        std::vector<std::size_t>& source_node_id_list = power_graph.get_source_node_id_list();
+        if (std::find(source_node_id_list.begin(), source_node_id_list.end(), node_id) == source_node_id_list.end()) {
+          source_node_id_list.push_back(node_id);
+        }
+        continue;
+      }
       power_node.get_instance_id_set().insert(power_pin.get_instance_id());
       std::vector<std::size_t>& node_id_list = power_graph.get_instance_node_id_list_map()[power_pin.get_instance_id()];
       if (std::find(node_id_list.begin(), node_id_list.end(), node_id) == node_id_list.end()) {
         node_id_list.push_back(node_id);
       }
-    }
-    for (std::size_t segment_idx = 0; segment_idx < power_net.get_wire_segment_list().size(); segment_idx++) {
-      PowerWireSegment& power_wire_segment = power_net.get_wire_segment_list()[segment_idx];
-      if (power_wire_segment.get_layer_idx() == power_pin.get_layer_idx() && isOnWireSegment(power_wire_segment, power_node)) {
-        appendWireNodeId(gb_model, segment_idx, node_id);
+      std::string pin_name = power_pin.get_pin_name();
+      std::size_t delimiter_pos = pin_name.rfind(':');
+      if (delimiter_pos != std::string::npos) {
+        pin_name = pin_name.substr(delimiter_pos + 1);
+      }
+      std::vector<std::size_t>& pin_node_id_list
+          = power_graph.get_instance_pin_node_id_list_map()[std::make_pair(power_pin.get_instance_id(), pin_name)];
+      if (std::find(pin_node_id_list.begin(), pin_node_id_list.end(), node_id) == pin_node_id_list.end()) {
+        pin_node_id_list.push_back(node_id);
+      }
+      if (use_imported_pin_area) {
+        double weight = total_weight > 0.0 ? pin_node_weights[node_id] / total_weight : 1.0 / pin_node_id_set.size();
+        power_graph.get_instance_node_weight_map()[power_pin.get_instance_id()][node_id] += weight;
+        power_graph.get_instance_pin_node_weight_map()[std::make_pair(power_pin.get_instance_id(), pin_name)][node_id] += weight;
       }
     }
   }
+  if (skipped_pin_num > 0) {
+    EMIRLOG.info(Loc::current(), "Skipped ", skipped_pin_num, " unconnected power pins in net ", power_net.get_net_name(), ", connected ",
+                 connected_pin_num, " pins");
+  }
 }
 
-void GraphBuilder::buildGeneratedSourceNodeList(PowerGraph& power_graph)
+void GraphBuilder::buildConfiguredSourceNodeList(PowerGraph& power_graph, PowerNet& power_net, GBModel& gb_model)
 {
-  if (!power_graph.get_source_node_id_list().empty()) {
-    return;
-  }
-  buildFullSourceNodeList(power_graph);
-}
-
-void GraphBuilder::buildFullSourceNodeList(PowerGraph& power_graph)
-{
-  int32_t top_layer_idx = -1;
-  for (PowerNode& power_node : power_graph.get_node_list()) {
-    top_layer_idx = std::max(top_layer_idx, power_node.get_layer_idx());
-  }
-  for (PowerNode& power_node : power_graph.get_node_list()) {
-    if (power_node.get_layer_idx() != top_layer_idx) {
+  for (PowerSource& source : EMIRDM.getDatabase().get_power_source_list()) {
+    if (source.get_net_type() != power_net.get_type()
+        || (!source.get_net_name().empty() && source.get_net_name() != power_net.get_net_name())) {
       continue;
     }
-    power_node.set_type(PowerNodeType::kSource);
-    power_node.set_is_source(true);
-    power_graph.get_source_node_id_list().push_back(power_node.get_node_id());
+    bool connected = false;
+    auto mark_source_node = [&](int32_t layer_idx, int32_t x, int32_t y) {
+      std::size_t node_id = getPowerNode(power_graph, layer_idx, x, y, PowerNodeType::kSource);
+      std::vector<std::size_t>& source_node_list = power_graph.get_source_node_id_list();
+      if (std::find(source_node_list.begin(), source_node_list.end(), node_id) == source_node_list.end()) {
+        source_node_list.push_back(node_id);
+      }
+      connected = true;
+      return node_id;
+    };
+    for (PowerVia& via : power_net.get_via_list()) {
+      if (via.get_bottom_layer_name() == source.get_layer_name() && via.get_bottom_x() == source.get_x()
+          && via.get_bottom_y() == source.get_y()) {
+        mark_source_node(via.get_bottom_layer_idx(), via.get_bottom_x(), via.get_bottom_y());
+      }
+      if (via.get_top_layer_name() == source.get_layer_name() && via.get_top_x() == source.get_x() && via.get_top_y() == source.get_y()) {
+        mark_source_node(via.get_top_layer_idx(), via.get_top_x(), via.get_top_y());
+      }
+    }
+    struct SourceConnection
+    {
+      std::size_t segment_idx;
+      int32_t x;
+      int32_t y;
+      double distance_squared;
+    };
+    std::vector<SourceConnection> wire_connections;
+    double nearest_distance_squared = connected ? 0.0 : std::numeric_limits<double>::max();
+    for (std::size_t segment_idx = 0; segment_idx < power_net.get_wire_segment_list().size(); segment_idx++) {
+      PowerWireSegment& segment = power_net.get_wire_segment_list()[segment_idx];
+      int32_t wire_x = 0;
+      int32_t wire_y = 0;
+      if (segment.get_layer_name() != source.get_layer_name()
+          || !getPointWireConnectionCoordinate(segment, source.get_x(), source.get_y(), wire_x, wire_y)) {
+        continue;
+      }
+      double dx = static_cast<double>(wire_x) - source.get_x();
+      double dy = static_cast<double>(wire_y) - source.get_y();
+      double distance_squared = dx * dx + dy * dy;
+      nearest_distance_squared = std::min(nearest_distance_squared, distance_squared);
+      wire_connections.push_back({segment_idx, wire_x, wire_y, distance_squared});
+    }
+    // A PLOC entry is a point contact. Clamping it to every nearby segment end
+    // creates extra ideal sources and bypasses real resistance near the pad.
+    // Keep all segments at the nearest contact (including a shared endpoint).
+    for (const SourceConnection& connection : wire_connections) {
+      if (connection.distance_squared != nearest_distance_squared) {
+        continue;
+      }
+      PowerWireSegment& segment = power_net.get_wire_segment_list()[connection.segment_idx];
+      std::size_t node_id = mark_source_node(segment.get_layer_idx(), connection.x, connection.y);
+      appendWireNodeId(gb_model, connection.segment_idx, node_id);
+    }
+    if (!connected) {
+      EMIRLOG.error(Loc::current(), "PLOC source ", source.get_name(), " is not on routed net ", power_net.get_net_name(), " at ",
+                    source.get_layer_name(), " (", source.get_x(), ",", source.get_y(), ") DBU");
+    }
   }
 }
 
@@ -317,13 +457,87 @@ bool GraphBuilder::isOnWireSegment(PowerWireSegment& power_wire_segment, int32_t
   if (power_wire_segment.get_first_x() == power_wire_segment.get_second_x()) {
     return min_y <= y && y <= max_y && std::abs(x - power_wire_segment.get_first_x()) <= half_width;
   }
-  EMIRLOG.error(Loc::current(), "The power wire segment is oblique!");
-  return false;
+  double dx = static_cast<double>(power_wire_segment.get_second_x() - power_wire_segment.get_first_x());
+  double dy = static_cast<double>(power_wire_segment.get_second_y() - power_wire_segment.get_first_y());
+  double length_squared = dx * dx + dy * dy;
+  if (length_squared <= EMIR_ERROR) {
+    return false;
+  }
+  double projection = ((x - power_wire_segment.get_first_x()) * dx + (y - power_wire_segment.get_first_y()) * dy) / length_squared;
+  if (projection < 0.0 || projection > 1.0) {
+    return false;
+  }
+  double projected_x = power_wire_segment.get_first_x() + projection * dx;
+  double projected_y = power_wire_segment.get_first_y() + projection * dy;
+  double distance_squared = (x - projected_x) * (x - projected_x) + (y - projected_y) * (y - projected_y);
+  return distance_squared <= static_cast<double>(half_width) * half_width;
 }
 
 bool GraphBuilder::isOnWireSegment(PowerWireSegment& power_wire_segment, PowerNode& power_node)
 {
   return isOnWireSegment(power_wire_segment, power_node.get_x(), power_node.get_y());
+}
+
+bool GraphBuilder::getPointWireConnectionCoordinate(PowerWireSegment& power_wire_segment, int32_t point_x, int32_t point_y, int32_t& wire_x,
+                                                    int32_t& wire_y)
+{
+  double first_x = power_wire_segment.get_first_x();
+  double first_y = power_wire_segment.get_first_y();
+  double dx = static_cast<double>(power_wire_segment.get_second_x()) - first_x;
+  double dy = static_cast<double>(power_wire_segment.get_second_y()) - first_y;
+  double length_squared = dx * dx + dy * dy;
+  if (length_squared <= EMIR_ERROR) {
+    return false;
+  }
+  double projection = ((point_x - first_x) * dx + (point_y - first_y) * dy) / length_squared;
+  projection = std::clamp(projection, 0.0, 1.0);
+  double projected_x = first_x + projection * dx;
+  double projected_y = first_y + projection * dy;
+  double distance_squared = (point_x - projected_x) * (point_x - projected_x) + (point_y - projected_y) * (point_y - projected_y);
+  double half_width = static_cast<double>(power_wire_segment.get_width()) / 2.0;
+  if (distance_squared > half_width * half_width) {
+    return false;
+  }
+  wire_x = static_cast<int32_t>(std::llround(projected_x));
+  wire_y = static_cast<int32_t>(std::llround(projected_y));
+  return true;
+}
+
+bool GraphBuilder::getPinWireConnectionCoordinate(PowerWireSegment& power_wire_segment, PowerPin& power_pin, int32_t& x, int32_t& y)
+{
+  int32_t half_width = power_wire_segment.get_width() / 2;
+  int32_t min_x = std::min(power_wire_segment.get_first_x(), power_wire_segment.get_second_x());
+  int32_t max_x = std::max(power_wire_segment.get_first_x(), power_wire_segment.get_second_x());
+  int32_t min_y = std::min(power_wire_segment.get_first_y(), power_wire_segment.get_second_y());
+  int32_t max_y = std::max(power_wire_segment.get_first_y(), power_wire_segment.get_second_y());
+  bool is_horizontal = power_wire_segment.get_first_y() == power_wire_segment.get_second_y();
+  bool is_vertical = power_wire_segment.get_first_x() == power_wire_segment.get_second_x();
+  if (!(is_horizontal || is_vertical)) {
+    EMIRLOG.error(Loc::current(), "The power wire segment is oblique!");
+  }
+
+  int32_t wire_low_x = is_horizontal ? min_x : power_wire_segment.get_first_x() - half_width;
+  int32_t wire_high_x = is_horizontal ? max_x : power_wire_segment.get_first_x() + half_width;
+  int32_t wire_low_y = is_vertical ? min_y : power_wire_segment.get_first_y() - half_width;
+  int32_t wire_high_y = is_vertical ? max_y : power_wire_segment.get_first_y() + half_width;
+  bool has_overlap = power_pin.get_low_x() <= wire_high_x && wire_low_x <= power_pin.get_high_x() && power_pin.get_low_y() <= wire_high_y
+                     && wire_low_y <= power_pin.get_high_y();
+  if (!has_overlap) {
+    return false;
+  }
+
+  if (is_horizontal) {
+    int32_t overlap_low_x = std::max(power_pin.get_low_x(), min_x);
+    int32_t overlap_high_x = std::min(power_pin.get_high_x(), max_x);
+    x = std::min(std::max(power_pin.get_x(), overlap_low_x), overlap_high_x);
+    y = power_wire_segment.get_first_y();
+  } else {
+    int32_t overlap_low_y = std::max(power_pin.get_low_y(), min_y);
+    int32_t overlap_high_y = std::min(power_pin.get_high_y(), max_y);
+    x = power_wire_segment.get_first_x();
+    y = std::min(std::max(power_pin.get_y(), overlap_low_y), overlap_high_y);
+  }
+  return true;
 }
 
 void GraphBuilder::buildWireEdgeList(PowerGraph& power_graph, PowerNet& power_net, GBModel& gb_model)
@@ -332,11 +546,12 @@ void GraphBuilder::buildWireEdgeList(PowerGraph& power_graph, PowerNet& power_ne
   for (std::size_t segment_idx = 0; segment_idx < power_wire_segment_list.size(); segment_idx++) {
     PowerWireSegment& power_wire_segment = power_wire_segment_list[segment_idx];
     std::vector<std::size_t>& node_id_list = gb_model.get_segment_node_id_list_map()[segment_idx];
-    bool is_horizontal = power_wire_segment.get_first_y() == power_wire_segment.get_second_y();
-    std::sort(node_id_list.begin(), node_id_list.end(), [&power_graph, is_horizontal](std::size_t first_node_id, std::size_t second_node_id) {
+    bool sort_by_x = std::abs(power_wire_segment.get_first_x() - power_wire_segment.get_second_x())
+                     >= std::abs(power_wire_segment.get_first_y() - power_wire_segment.get_second_y());
+    std::sort(node_id_list.begin(), node_id_list.end(), [&power_graph, sort_by_x](std::size_t first_node_id, std::size_t second_node_id) {
       PowerNode& first_power_node = power_graph.get_node_list()[first_node_id];
       PowerNode& second_power_node = power_graph.get_node_list()[second_node_id];
-      return is_horizontal ? first_power_node.get_x() < second_power_node.get_x() : first_power_node.get_y() < second_power_node.get_y();
+      return sort_by_x ? first_power_node.get_x() < second_power_node.get_x() : first_power_node.get_y() < second_power_node.get_y();
     });
     for (std::size_t node_idx = 1; node_idx < node_id_list.size(); node_idx++) {
       PowerNode& first_power_node = power_graph.get_node_list()[node_id_list[node_idx - 1]];
@@ -345,12 +560,22 @@ void GraphBuilder::buildWireEdgeList(PowerGraph& power_graph, PowerNet& power_ne
       if (length == 0) {
         continue;
       }
-      if (power_wire_segment.get_width() <= 0 || power_wire_segment.get_resistance_per_square() <= 0.0) {
+      if (power_wire_segment.get_width() <= 0
+          || (!power_wire_segment.get_has_explicit_resistance() && power_wire_segment.get_resistance_per_square() <= 0.0)) {
         EMIRLOG.error(Loc::current(), "The power wire resistance data is invalid!");
       }
-      double resistance = power_wire_segment.get_resistance_per_square() * static_cast<double>(length) / power_wire_segment.get_width();
-      addPowerEdge(power_graph, PowerEdgeType::kWire, first_power_node.get_node_id(), second_power_node.get_node_id(), power_wire_segment.get_layer_idx(),
-                   power_wire_segment.get_width(), length, resistance);
+      int32_t segment_length = std::abs(power_wire_segment.get_first_x() - power_wire_segment.get_second_x())
+                               + std::abs(power_wire_segment.get_first_y() - power_wire_segment.get_second_y());
+      double resistance = power_wire_segment.get_has_explicit_resistance()
+                              ? power_wire_segment.get_resistance() * static_cast<double>(length) / segment_length
+                              : power_wire_segment.get_resistance_per_square() * static_cast<double>(length) / power_wire_segment.get_width();
+      PowerEdge* power_edge = addPowerEdge(power_graph, PowerEdgeType::kWire, first_power_node.get_node_id(), second_power_node.get_node_id(),
+                                           power_wire_segment.get_layer_idx(), power_wire_segment.get_width(), length, resistance,
+                                           power_net.get_has_explicit_parasitics());
+      if (power_edge != nullptr) {
+        power_edge->set_layer_name(power_wire_segment.get_layer_name());
+        power_edge->set_is_em_checkable(power_wire_segment.get_is_em_checkable());
+      }
     }
   }
 }
@@ -358,26 +583,40 @@ void GraphBuilder::buildWireEdgeList(PowerGraph& power_graph, PowerNet& power_ne
 void GraphBuilder::buildViaEdgeList(PowerGraph& power_graph, PowerNet& power_net)
 {
   for (PowerVia& power_via : power_net.get_via_list()) {
-    std::size_t bottom_node_id = getPowerNode(power_graph, power_via.get_bottom_layer_idx(), power_via.get_x(), power_via.get_y(), PowerNodeType::kVia);
-    std::size_t top_node_id = getPowerNode(power_graph, power_via.get_top_layer_idx(), power_via.get_x(), power_via.get_y(), PowerNodeType::kVia);
+    std::size_t bottom_node_id = getPowerNode(power_graph, power_via.get_bottom_layer_idx(), power_via.get_bottom_x(), power_via.get_bottom_y(),
+                                              PowerNodeType::kVia);
+    std::size_t top_node_id
+        = getPowerNode(power_graph, power_via.get_top_layer_idx(), power_via.get_top_x(), power_via.get_top_y(), PowerNodeType::kVia);
     if (power_via.get_resistance() <= 0.0) {
       EMIRLOG.error(Loc::current(), "The power via resistance data is invalid!");
     }
-    addPowerEdge(power_graph, PowerEdgeType::kVia, bottom_node_id, top_node_id, power_via.get_bottom_layer_idx(), 0, 0, power_via.get_resistance());
+    PowerEdge* power_edge
+        = addPowerEdge(power_graph, PowerEdgeType::kVia, bottom_node_id, top_node_id, power_via.get_bottom_layer_idx(), 0, 0,
+                       power_via.get_resistance(), power_net.get_has_explicit_parasitics());
+    if (power_edge != nullptr) {
+      power_edge->set_layer_name(power_via.get_bottom_layer_name());
+      power_edge->set_via_name(power_via.get_via_name());
+      power_edge->set_cut_num(power_via.get_cut_num());
+      power_edge->set_cut_area_um2(power_via.get_cut_area_um2());
+      power_edge->set_cut_low_x(power_via.get_cut_low_x());
+      power_edge->set_cut_low_y(power_via.get_cut_low_y());
+      power_edge->set_cut_high_x(power_via.get_cut_high_x());
+      power_edge->set_cut_high_y(power_via.get_cut_high_y());
+    }
   }
 }
 
-void GraphBuilder::addPowerEdge(PowerGraph& power_graph, PowerEdgeType power_edge_type, std::size_t first_node_id, std::size_t second_node_id,
-                                int32_t layer_idx, int32_t width, int32_t length, double resistance)
+PowerEdge* GraphBuilder::addPowerEdge(PowerGraph& power_graph, PowerEdgeType power_edge_type, std::size_t first_node_id, std::size_t second_node_id,
+                                      int32_t layer_idx, int32_t width, int32_t length, double resistance, bool allow_parallel)
 {
   if (first_node_id == second_node_id) {
-    return;
+    return nullptr;
   }
   for (PowerEdge& power_edge : power_graph.get_edge_list()) {
     bool is_same_node_pair = (power_edge.get_first_node_id() == first_node_id && power_edge.get_second_node_id() == second_node_id)
                              || (power_edge.get_first_node_id() == second_node_id && power_edge.get_second_node_id() == first_node_id);
-    if (is_same_node_pair && power_edge.get_type() == power_edge_type) {
-      return;
+    if (!allow_parallel && is_same_node_pair && power_edge.get_type() == power_edge_type) {
+      return &power_edge;
     }
   }
   PowerEdge power_edge;
@@ -390,12 +629,13 @@ void GraphBuilder::addPowerEdge(PowerGraph& power_graph, PowerEdgeType power_edg
   power_edge.set_length(length);
   power_edge.set_resistance(resistance);
   power_graph.get_edge_list().push_back(power_edge);
+  return &power_graph.get_edge_list().back();
 }
 
 void GraphBuilder::checkPowerGraphConnectivity(PowerGraph& power_graph)
 {
   if (power_graph.get_source_node_id_list().empty()) {
-    EMIRLOG.error(Loc::current(), "The power graph does not contain a source node!");
+    EMIRLOG.error(Loc::current(), "The power graph does not have a PLOC or IO source: ", power_graph.get_net_name());
   }
   std::map<std::size_t, std::vector<std::size_t>> node_adjacency_map;
   for (PowerEdge& power_edge : power_graph.get_edge_list()) {

--- a/src/operation/iEMIR/source/module/graph_builder/GraphBuilder.hpp
+++ b/src/operation/iEMIR/source/module/graph_builder/GraphBuilder.hpp
@@ -60,15 +60,17 @@ class GraphBuilder
   bool getWireIntersectionCoordinate(PowerWireSegment& first_power_wire_segment, PowerWireSegment& second_power_wire_segment, int32_t& x, int32_t& y);
   void appendWireNodeId(GBModel& gb_model, std::size_t segment_idx, std::size_t node_id);
   void buildViaNodeList(PowerGraph& power_graph, PowerNet& power_net, GBModel& gb_model);
+  void buildConfiguredSourceNodeList(PowerGraph& power_graph, PowerNet& power_net, GBModel& gb_model);
   void buildPinNodeList(PowerGraph& power_graph, PowerNet& power_net, GBModel& gb_model);
-  void buildGeneratedSourceNodeList(PowerGraph& power_graph);
-  void buildFullSourceNodeList(PowerGraph& power_graph);
+  bool getPointWireConnectionCoordinate(PowerWireSegment& power_wire_segment, int32_t point_x, int32_t point_y, int32_t& wire_x,
+                                        int32_t& wire_y);
+  bool getPinWireConnectionCoordinate(PowerWireSegment& power_wire_segment, PowerPin& power_pin, int32_t& x, int32_t& y);
   bool isOnWireSegment(PowerWireSegment& power_wire_segment, int32_t x, int32_t y);
   bool isOnWireSegment(PowerWireSegment& power_wire_segment, PowerNode& power_node);
   void buildWireEdgeList(PowerGraph& power_graph, PowerNet& power_net, GBModel& gb_model);
   void buildViaEdgeList(PowerGraph& power_graph, PowerNet& power_net);
-  void addPowerEdge(PowerGraph& power_graph, PowerEdgeType power_edge_type, std::size_t first_node_id, std::size_t second_node_id, int32_t layer_idx,
-                    int32_t width, int32_t length, double resistance);
+  PowerEdge* addPowerEdge(PowerGraph& power_graph, PowerEdgeType power_edge_type, std::size_t first_node_id, std::size_t second_node_id,
+                          int32_t layer_idx, int32_t width, int32_t length, double resistance, bool allow_parallel = false);
   void checkPowerGraphConnectivity(PowerGraph& power_graph);
 };
 

--- a/src/operation/iEMIR/source/module/ir_analyzer/IRAnalyzer.cpp
+++ b/src/operation/iEMIR/source/module/ir_analyzer/IRAnalyzer.cpp
@@ -24,6 +24,7 @@
 #include "Monitor.hpp"
 #include "PowerEdge.hpp"
 #include "PowerNode.hpp"
+#include "Utility.hpp"
 
 namespace iemir {
 
@@ -59,7 +60,18 @@ void IRAnalyzer::analyze()
   Monitor monitor;
   EMIRLOG.info(Loc::current(), "Starting...");
 
-  analyzePowerGraphList();
+  std::string diagnostics_path = EMIRUTIL.getString(EMIRDM.getConfig().ia_temp_directory_path, "solver_diagnostics.csv");
+  std::ofstream diagnostics_file(diagnostics_path);
+  if (!diagnostics_file) {
+    EMIRLOG.error(Loc::current(), "Cannot create IR solver diagnostics: ", diagnostics_path);
+  }
+  diagnostics_file << "net,net_type,node_count,edge_count,source_count,pin_mapped_current_a,generic_current_a,pin_current_coverage_pct,"
+                      "load_current_a,source_current_a,current_balance_error_a,"
+                      "current_balance_relative,max_abs_residual_a,l2_residual_a,relative_l2_residual,"
+                      "source_node_load_current_a,total_load_current_a\n";
+  analyzePowerGraphList(diagnostics_file);
+  diagnostics_file.close();
+  EMIRLOG.info(Loc::current(), "IR solver diagnostics: ", diagnostics_path);
 
   EMIRLOG.info(Loc::current(), "Completed", monitor.getStatsInfo());
 }
@@ -68,17 +80,17 @@ void IRAnalyzer::analyze()
 
 IRAnalyzer* IRAnalyzer::_ia_instance = nullptr;
 
-void IRAnalyzer::analyzePowerGraphList()
+void IRAnalyzer::analyzePowerGraphList(std::ofstream& diagnostics_file)
 {
   for (std::pair<const std::string, PowerGraph>& power_graph_pair : EMIRDM.getDatabase().get_power_graph_map()) {
-    analyzePowerGraph(power_graph_pair.second);
+    analyzePowerGraph(power_graph_pair.second, diagnostics_file);
   }
 }
 
-void IRAnalyzer::analyzePowerGraph(PowerGraph& power_graph)
+void IRAnalyzer::analyzePowerGraph(PowerGraph& power_graph, std::ofstream& diagnostics_file)
 {
   IAModel ia_model = initIAModel(power_graph);
-  solveNodeVoltage(power_graph, ia_model);
+  solveNodeVoltage(power_graph, ia_model, diagnostics_file);
 }
 
 IAModel IRAnalyzer::initIAModel(PowerGraph& power_graph)
@@ -149,32 +161,78 @@ void IRAnalyzer::buildNodeCurrentMap(PowerGraph& power_graph, IAModel& ia_model)
 void IRAnalyzer::buildInstanceNodeCurrent(PowerGraph& power_graph, uint64_t instance_id, InstancePower& instance_power, IAModel& ia_model)
 {
   double total_power = instance_power.get_total_power();
-  if (std::abs(total_power) <= EMIR_ERROR) {
-    return;
-  }
-  if (instance_power.get_voltage() <= EMIR_ERROR) {
+  if (!instance_power.get_has_average_current() && instance_power.get_voltage() <= EMIR_ERROR) {
     EMIRLOG.error(Loc::current(), "The instance power voltage is invalid!");
+  }
+  double instance_current = instance_power.get_has_average_current() ? instance_power.get_average_current()
+                                                                    : total_power / instance_power.get_voltage();
+  // PT-PX currents for small blocks commonly fall below the generic 1e-6
+  // geometry/voltage tolerance. Only an actual zero means there is no load.
+  if (instance_current == 0.0) {
+    return;
   }
   int32_t power_graph_num = getInstancePowerGraphNum(instance_id, power_graph.get_net_type());
   if (power_graph_num <= 0) {
     EMIRLOG.error(Loc::current(), "The instance power graph mapping is invalid!");
   }
+  double current_sign = power_graph.get_net_type() == PowerNetType::kPower ? -1.0 : 1.0;
+  auto distribute_current = [&ia_model](const std::set<std::size_t>& node_ids, const std::map<std::size_t, double>& weights,
+                                        double current) {
+    double total_weight = 0.0;
+    for (std::size_t node_id : node_ids) {
+      auto weight = weights.find(node_id);
+      if (weight != weights.end()) {
+        total_weight += weight->second;
+      }
+    }
+    for (std::size_t node_id : node_ids) {
+      auto weight = weights.find(node_id);
+      double fraction = total_weight > 0.0 ? (weight == weights.end() ? 0.0 : weight->second / total_weight) : 1.0 / node_ids.size();
+      ia_model.get_node_current_map()[node_id] += current * fraction;
+    }
+  };
+  if (power_graph.get_net_type() == PowerNetType::kPower && !instance_power.get_average_current_by_pin_name_map().empty()) {
+    double mapped_pin_current = 0.0;
+    for (const std::pair<const std::string, double>& pin_current_pair : instance_power.get_average_current_by_pin_name_map()) {
+      auto key = std::make_pair(instance_id, pin_current_pair.first);
+      auto pin_node_iter = power_graph.get_instance_pin_node_id_list_map().find(key);
+      if (pin_node_iter == power_graph.get_instance_pin_node_id_list_map().end()) {
+        continue;
+      }
+      std::set<std::size_t> pin_node_id_set;
+      for (std::size_t node_id : pin_node_iter->second) {
+        pin_node_id_set.insert(node_id);
+      }
+      if (pin_node_id_set.empty()) {
+        continue;
+      }
+      distribute_current(pin_node_id_set, power_graph.get_instance_pin_node_weight_map()[key], current_sign * pin_current_pair.second);
+      mapped_pin_current += pin_current_pair.second;
+    }
+    if (mapped_pin_current > 0.0) {
+      ia_model.add_pin_mapped_current(mapped_pin_current);
+      double relative_unmapped = std::abs(instance_current - mapped_pin_current) / std::max(std::abs(instance_current), 1.0e-30);
+      if (relative_unmapped > 1.0e-4) {
+        EMIRLOG.warn(Loc::current(), "PG-pin current mapping is incomplete for instance id ", instance_id, ": mapped=", mapped_pin_current,
+                     " A, total=", instance_current, " A");
+        instance_current -= mapped_pin_current;
+      } else {
+        return;
+      }
+    }
+  }
   std::set<std::size_t> node_id_set;
   for (std::size_t node_id : power_graph.get_instance_node_id_list_map()[instance_id]) {
-    if (ia_model.get_source_node_id_set().count(node_id) == 0) {
-      node_id_set.insert(node_id);
-    }
+    node_id_set.insert(node_id);
   }
   if (node_id_set.empty()) {
     return;
   }
-  double node_current = total_power / instance_power.get_voltage() / power_graph_num / node_id_set.size();
-  if (power_graph.get_net_type() == PowerNetType::kPower) {
-    node_current = -node_current;
-  }
-  for (std::size_t node_id : node_id_set) {
-    ia_model.get_node_current_map()[node_id] += node_current;
-  }
+  ia_model.add_generic_current(instance_current / power_graph_num);
+  // A load at an ideal source is supplied locally. Keep its original share;
+  // the Dirichlet elimination below omits it from the unknown-node RHS.
+  // Removing source nodes before normalization transfers that load elsewhere.
+  distribute_current(node_id_set, power_graph.get_instance_node_weight_map()[instance_id], current_sign * instance_current / power_graph_num);
 }
 
 int32_t IRAnalyzer::getInstancePowerGraphNum(uint64_t instance_id, PowerNetType power_net_type)
@@ -189,7 +247,7 @@ int32_t IRAnalyzer::getInstancePowerGraphNum(uint64_t instance_id, PowerNetType 
   return power_graph_num;
 }
 
-void IRAnalyzer::solveNodeVoltage(PowerGraph& power_graph, IAModel& ia_model)
+void IRAnalyzer::solveNodeVoltage(PowerGraph& power_graph, IAModel& ia_model, std::ofstream& diagnostics_file)
 {
   std::size_t matrix_size = ia_model.get_matrix_idx_to_node_id_list().size();
   std::vector<double> node_voltage_list(matrix_size, ia_model.get_source_voltage());
@@ -249,6 +307,42 @@ void IRAnalyzer::solveNodeVoltage(PowerGraph& power_graph, IAModel& ia_model)
   if (conductance_solver.info() != Eigen::Success) {
     EMIRLOG.error(Loc::current(), "The power conductance matrix solve failed!");
   }
+  Eigen::VectorXd residual_vector = conductance_matrix * voltage_vector - current_vector;
+  double max_abs_residual = residual_vector.size() == 0 ? 0.0 : residual_vector.cwiseAbs().maxCoeff();
+  double l2_residual = residual_vector.norm();
+  double relative_l2_residual = l2_residual / std::max(current_vector.norm(), 1.0e-30);
+
+  double load_current = 0.0;
+  double source_node_load_current = 0.0;
+  for (const std::pair<const std::size_t, double>& node_current_pair : ia_model.get_node_current_map()) {
+    if (ia_model.get_node_id_to_matrix_idx_map().count(node_current_pair.first) != 0) {
+      load_current += node_current_pair.second;
+    } else if (ia_model.get_source_node_id_set().count(node_current_pair.first) != 0) {
+      source_node_load_current += node_current_pair.second;
+    }
+  }
+  double current_balance_error = residual_vector.sum();
+  double source_current = -load_current + current_balance_error;
+  double current_balance_relative = std::abs(current_balance_error) / std::max(std::abs(load_current), 1.0e-30);
+  double classified_current = ia_model.get_pin_mapped_current() + ia_model.get_generic_current();
+  double pin_current_coverage = classified_current > 1.0e-30 ? 100.0 * ia_model.get_pin_mapped_current() / classified_current : 0.0;
+  diagnostics_file << std::setprecision(12) << power_graph.get_net_name() << ','
+                   << (power_graph.get_net_type() == PowerNetType::kPower ? "POWER" : "GROUND") << ',' << power_graph.get_node_list().size()
+                   << ',' << power_graph.get_edge_list().size() << ',' << ia_model.get_source_node_id_set().size() << ','
+                   << ia_model.get_pin_mapped_current() << ',' << ia_model.get_generic_current() << ',' << pin_current_coverage << ',' << load_current << ','
+                   << source_current << ',' << current_balance_error << ',' << current_balance_relative << ',' << max_abs_residual << ','
+                   << l2_residual << ',' << relative_l2_residual << ',' << source_node_load_current << ','
+                   << load_current + source_node_load_current << '\n';
+  EMIRLOG.info(Loc::current(), "IR solve ", power_graph.get_net_name(), ": relative_residual=", relative_l2_residual,
+               ", current_balance=", current_balance_relative, ", load_current=", load_current, " A");
+  if (!std::isfinite(relative_l2_residual) || !std::isfinite(current_balance_relative) || relative_l2_residual > 1.0e-6
+      || current_balance_relative > 1.0e-4) {
+    EMIRLOG.error(Loc::current(), "IR solve failed residual/current-balance validation for net ", power_graph.get_net_name());
+  } else if (current_balance_relative > 1.0e-6) {
+    EMIRLOG.warn(Loc::current(), "IR solve current-balance error exceeds 1 ppm for net ", power_graph.get_net_name(), ": ",
+                 current_balance_relative);
+  }
+
   for (std::size_t matrix_idx = 0; matrix_idx < matrix_size; matrix_idx++) {
     node_voltage_list[matrix_idx] = voltage_vector[matrix_idx];
   }

--- a/src/operation/iEMIR/source/module/ir_analyzer/IRAnalyzer.hpp
+++ b/src/operation/iEMIR/source/module/ir_analyzer/IRAnalyzer.hpp
@@ -46,15 +46,15 @@ class IRAnalyzer
   IRAnalyzer& operator=(const IRAnalyzer& other) = delete;
   IRAnalyzer& operator=(IRAnalyzer&& other) = delete;
   // function
-  void analyzePowerGraphList();
-  void analyzePowerGraph(PowerGraph& power_graph);
+  void analyzePowerGraphList(std::ofstream& diagnostics_file);
+  void analyzePowerGraph(PowerGraph& power_graph, std::ofstream& diagnostics_file);
   IAModel initIAModel(PowerGraph& power_graph);
   void buildSourceVoltage(PowerGraph& power_graph, IAModel& ia_model);
   void buildNodeMatrixIndex(PowerGraph& power_graph, IAModel& ia_model);
   void buildNodeCurrentMap(PowerGraph& power_graph, IAModel& ia_model);
   void buildInstanceNodeCurrent(PowerGraph& power_graph, uint64_t instance_id, InstancePower& instance_power, IAModel& ia_model);
   int32_t getInstancePowerGraphNum(uint64_t instance_id, PowerNetType power_net_type);
-  void solveNodeVoltage(PowerGraph& power_graph, IAModel& ia_model);
+  void solveNodeVoltage(PowerGraph& power_graph, IAModel& ia_model, std::ofstream& diagnostics_file);
   void updatePowerNodeVoltage(PowerGraph& power_graph, IAModel& ia_model, std::vector<double>& node_voltage_list);
 };
 

--- a/src/operation/iEMIR/source/module/ir_analyzer/ia_data_manager/IAModel.hpp
+++ b/src/operation/iEMIR/source/module/ir_analyzer/ia_data_manager/IAModel.hpp
@@ -31,8 +31,12 @@ class IAModel
   std::vector<std::size_t>& get_matrix_idx_to_node_id_list() { return _matrix_idx_to_node_id_list; }
   std::map<std::size_t, double>& get_node_current_map() { return _node_current_map; }
   double get_source_voltage() { return _source_voltage; }
+  double get_pin_mapped_current() { return _pin_mapped_current; }
+  double get_generic_current() { return _generic_current; }
   // setter
   void set_source_voltage(double source_voltage) { _source_voltage = source_voltage; }
+  void add_pin_mapped_current(double current) { _pin_mapped_current += std::abs(current); }
+  void add_generic_current(double current) { _generic_current += std::abs(current); }
   // function
 
  private:
@@ -41,6 +45,8 @@ class IAModel
   std::vector<std::size_t> _matrix_idx_to_node_id_list;
   std::map<std::size_t, double> _node_current_map;
   double _source_voltage = 0.0;
+  double _pin_mapped_current = 0.0;
+  double _generic_current = 0.0;
 };
 
 }  // namespace iemir

--- a/src/operation/iEMIR/test/CMakeLists.txt
+++ b/src/operation/iEMIR/test/CMakeLists.txt
@@ -5,8 +5,11 @@ add_executable(iemir_ir_em_test
 target_link_libraries(iemir_ir_em_test
     PRIVATE
     iemir_data_manager
+    iemir_graph_builder
     iemir_ir_analyzer
     iemir_em_analyzer
     iemir_emir_reporter
     iemir_toolkit
 )
+
+add_test(NAME iemir_ir_em_test COMMAND iemir_ir_em_test)

--- a/src/operation/iEMIR/test/iemir_ir_em_test.cpp
+++ b/src/operation/iEMIR/test/iemir_ir_em_test.cpp
@@ -21,15 +21,23 @@
 #include "DataManager.hpp"
 #include "EMAnalyzer.hpp"
 #include "EMIRReporter.hpp"
+#include "GraphBuilder.hpp"
 #include "IRAnalyzer.hpp"
 #include "InstancePower.hpp"
 #include "Logger.hpp"
 #include "PowerEdge.hpp"
 #include "PowerEdgeType.hpp"
 #include "PowerGraph.hpp"
+#include "PowerNet.hpp"
 #include "PowerNetType.hpp"
 #include "PowerNode.hpp"
 #include "PowerNodeType.hpp"
+#include "PowerPin.hpp"
+#include "PowerSource.hpp"
+#include "PowerVia.hpp"
+#include "PowerWireSegment.hpp"
+#include "PTPXPowerReader.hpp"
+#include "RedHawkResNetworkReader.hpp"
 
 namespace {
 
@@ -52,12 +60,18 @@ iemir::PowerGraph buildPowerGraph(const std::string& net_name, iemir::PowerNetTy
   instance_node.get_instance_id_set().insert(1);
   power_graph.get_node_list().push_back(instance_node);
   power_graph.get_instance_node_id_list_map()[1].push_back(instance_node.get_node_id());
+  if (power_net_type == iemir::PowerNetType::kPower) {
+    power_graph.get_instance_pin_node_id_list_map()[std::make_pair(1, "VDD")].push_back(instance_node.get_node_id());
+  }
 
   iemir::PowerEdge power_edge;
   power_edge.set_edge_id(0);
   power_edge.set_type(iemir::PowerEdgeType::kWire);
   power_edge.set_first_node_id(source_node.get_node_id());
   power_edge.set_second_node_id(instance_node.get_node_id());
+  power_edge.set_layer_idx(1);
+  power_edge.set_layer_name("MET1");
+  power_edge.set_width(1000);
   power_edge.set_resistance(1.0);
   power_graph.get_edge_list().push_back(power_edge);
   return power_graph;
@@ -70,6 +84,33 @@ bool checkPowerGraph(iemir::PowerGraph& power_graph, double expected_voltage)
   return std::abs(voltage - expected_voltage) <= EMIR_ERROR && std::abs(current - 1.0) <= EMIR_ERROR;
 }
 
+bool checkSubMicroampLoad()
+{
+  constexpr double kLoadCurrent = 5.0e-7;
+  iemir::InstancePower instance_power;
+  instance_power.set_instance_id(1);
+  instance_power.set_voltage(1.0);
+  instance_power.set_average_current(kLoadCurrent);
+
+  EMIRDM.getDatabase().get_instance_power_map().clear();
+  EMIRDM.getDatabase().get_power_graph_map().clear();
+  EMIRDM.getDatabase().get_instance_power_map()[1] = instance_power;
+  EMIRDM.getDatabase().get_power_graph_map()["VDD"] = buildPowerGraph("VDD", iemir::PowerNetType::kPower);
+
+  iemir::IRAnalyzer::initInst();
+  EMIRIA.analyze();
+  iemir::IRAnalyzer::destroyInst();
+
+  iemir::PowerGraph& power_graph = EMIRDM.getDatabase().get_power_graph_map().at("VDD");
+  const double voltage = power_graph.get_node_list()[1].get_voltage();
+  const double current = power_graph.get_node_list()[1].get_current();
+  const bool is_pass = std::abs(voltage - (1.0 - kLoadCurrent)) <= 1.0e-12
+                       && std::abs(current + kLoadCurrent) <= 1.0e-12;
+  EMIRDM.getDatabase().get_instance_power_map().clear();
+  EMIRDM.getDatabase().get_power_graph_map().clear();
+  return is_pass;
+}
+
 bool checkReport(const std::string& report_file_path, const std::string& content)
 {
   std::ifstream report_file(report_file_path);
@@ -77,17 +118,327 @@ bool checkReport(const std::string& report_file_path, const std::string& content
   return report_content.find(content) != std::string::npos;
 }
 
+bool checkShiftedViaGraph(const std::filesystem::path& directory)
+{
+  iemir::PowerNet power_net;
+  power_net.set_net_name("SHIFTED_VIA");
+  power_net.set_type(iemir::PowerNetType::kPower);
+  power_net.set_has_explicit_parasitics(true);
+
+  iemir::PowerWireSegment bottom_wire;
+  bottom_wire.set_layer_idx(1);
+  bottom_wire.set_layer_name("MET1");
+  bottom_wire.set_first_x(0);
+  bottom_wire.set_first_y(0);
+  bottom_wire.set_second_x(10);
+  bottom_wire.set_second_y(0);
+  bottom_wire.set_width(2);
+  bottom_wire.set_resistance(1.0);
+  power_net.get_wire_segment_list().push_back(bottom_wire);
+
+  iemir::PowerWireSegment top_wire;
+  top_wire.set_layer_idx(2);
+  top_wire.set_layer_name("MET2");
+  top_wire.set_first_x(20);
+  top_wire.set_first_y(0);
+  top_wire.set_second_x(30);
+  top_wire.set_second_y(0);
+  top_wire.set_width(2);
+  top_wire.set_resistance(1.0);
+  power_net.get_wire_segment_list().push_back(top_wire);
+
+  iemir::PowerVia power_via;
+  power_via.set_bottom_layer_idx(1);
+  power_via.set_top_layer_idx(2);
+  power_via.set_via_name("VIA_SHIFTED");
+  power_via.set_x(12);
+  power_via.set_y(0);
+  power_via.set_bottom_x(10);
+  power_via.set_bottom_y(0);
+  power_via.set_top_x(20);
+  power_via.set_top_y(0);
+  power_via.set_resistance(2.0);
+  power_net.get_via_list().push_back(power_via);
+
+  iemir::PowerPin source_pin;
+  source_pin.set_layer_idx(1);
+  source_pin.set_x(0);
+  source_pin.set_y(0);
+  source_pin.set_is_source(true);
+  power_net.get_pin_list().push_back(source_pin);
+
+  EMIRDM.getDatabase().get_power_net_map().clear();
+  EMIRDM.getDatabase().get_power_net_map()[power_net.get_net_name()] = power_net;
+  iemir::GraphBuilder::initInst();
+  EMIRGB.build();
+  iemir::GraphBuilder::destroyInst();
+
+  iemir::PowerGraph& power_graph = EMIRDM.getDatabase().get_power_graph_map().at(power_net.get_net_name());
+  auto& coordinate_node_map = power_graph.get_coordinate_node_id_map();
+  bool is_pass = power_graph.get_is_connected() && power_graph.get_node_list().size() == 4 && power_graph.get_edge_list().size() == 3
+                 && coordinate_node_map.count(std::make_tuple(1, 10, 0)) == 1 && coordinate_node_map.count(std::make_tuple(2, 20, 0)) == 1
+                 && coordinate_node_map.count(std::make_tuple(1, 15, 0)) == 0 && coordinate_node_map.count(std::make_tuple(2, 15, 0)) == 0;
+  EMIRDM.getDatabase().set_design_name("shifted_via");
+  EMIRDM.getDatabase().set_micron_dbu(1000);
+  EMIRDM.getConfig().er_temp_directory_path = directory.string() + "/";
+  for (auto& edge : power_graph.get_edge_list()) {
+    if (edge.get_type() == iemir::PowerEdgeType::kVia) {
+      edge.set_current(1.0e-6);
+    }
+  }
+  iemir::EMIRReporter::initInst();
+  EMIRER.report();
+  iemir::EMIRReporter::destroyInst();
+  is_pass = is_pass && checkReport((directory / "shifted_via.em.worst").string(), "via VIA_SHIFTED  (0.012,0.000)")
+            && checkReport((directory / "em.rpt").string(), "via VIA_SHIFTED  (0.012,0.000)")
+            && checkReport((directory / "shifted_via.res_network").string(), "VIA_SHIFTED SHIFTED_VIA (0.012 0.000)")
+            && checkReport((directory / "shifted_via.em.worst").string(), "1.000000e-06")
+            && coordinate_node_map.count(std::make_tuple(1, 12, 0)) == 0 && coordinate_node_map.count(std::make_tuple(2, 12, 0)) == 0;
+  EMIRDM.getDatabase().get_power_net_map().clear();
+  EMIRDM.getDatabase().get_power_graph_map().clear();
+  return is_pass;
+}
+
+bool checkPTPXPowerReader(const std::filesystem::path& directory)
+{
+  std::filesystem::path file_path = directory / "ptpx_instance_power.tsv";
+  std::ofstream output(file_path);
+  output << "# iEMIR_PTPX_INSTANCE_POWER_V1\n";
+  output << "instance_name\tvoltage_v\tinternal_power_w\tswitching_power_w\tleakage_power_w\ttotal_power_w\taverage_current_a\n";
+  output << "U1\t1.2\t1e-6\t2e-6\t3e-6\t6e-6\t5e-6\n";
+  output.close();
+  std::vector<iemir::PTPXPowerRecord> records = iemir::PTPXPowerReader::read(file_path.string());
+  return records.size() == 1 && records.front().instance_name == "U1" && std::abs(records.front().total_power - 6.0e-6) <= 1.0e-18
+         && std::abs(records.front().average_current - 5.0e-6) <= 1.0e-18;
+}
+
+bool checkPointSourceDoesNotShortNearbySegment()
+{
+  bool is_pass = true;
+  // Exercise an interior contact, a shared endpoint, and an off-grid PLOC
+  // just outside the wire end. Segment order must not affect the contact.
+  for (bool reverse_order : {false, true}) {
+    for (int32_t source_x : {12, 10, -1}) {
+      iemir::PowerNet net;
+      net.set_net_name("POINT_SOURCE");
+      net.set_type(iemir::PowerNetType::kPower);
+      net.set_has_explicit_parasitics(true);
+      for (int32_t index : {0, 1}) {
+        int32_t start = 10 * (reverse_order ? 1 - index : index);
+        iemir::PowerWireSegment wire;
+        wire.set_layer_idx(1);
+        wire.set_layer_name("MET1");
+        wire.set_first_x(start);
+        wire.set_first_y(0);
+        wire.set_second_x(start + 10);
+        wire.set_second_y(0);
+        wire.set_width(6);
+        wire.set_resistance(1.0);
+        net.get_wire_segment_list().push_back(wire);
+      }
+      iemir::PowerSource source;
+      source.set_name("PLOC");
+      source.set_net_name(net.get_net_name());
+      source.set_net_type(net.get_type());
+      source.set_layer_name("MET1");
+      source.set_x(source_x);
+      source.set_y(0);
+      EMIRDM.getDatabase().get_power_net_map()[net.get_net_name()] = net;
+      EMIRDM.getDatabase().get_power_source_list().push_back(source);
+      iemir::GraphBuilder::initInst();
+      EMIRGB.build();
+      iemir::GraphBuilder::destroyInst();
+      auto& graph = EMIRDM.getDatabase().get_power_graph_map().at(net.get_net_name());
+      auto contact = graph.get_coordinate_node_id_map().at(std::make_tuple(1, std::max(source_x, 0), 0));
+      is_pass = is_pass && graph.get_is_connected() && graph.get_source_node_id_list() == std::vector<std::size_t>{contact};
+      double total_resistance = 0.0;
+      for (auto& edge : graph.get_edge_list()) {
+        total_resistance += edge.get_resistance();
+      }
+      is_pass = is_pass && std::abs(total_resistance - 2.0) < 1e-12;
+      EMIRDM.getDatabase().get_power_source_list().clear();
+      EMIRDM.getDatabase().get_power_net_map().clear();
+      EMIRDM.getDatabase().get_power_graph_map().clear();
+    }
+  }
+  return is_pass;
+}
+
+bool checkRedHawkResNetworkReader(const std::filesystem::path& directory)
+{
+  std::filesystem::path file_path = directory / "redhawk.res_network";
+  std::ofstream output(file_path);
+  output << "W 10 MET1 VDD 0 0 10 0 10 2 0 2 2 1 h\n";
+  output << "WS 10_1 0 1 10 1 0 0 0 r 0.25 1\n";
+  output << "W 11 MET2 VSS 20 0 22 0 22 8 20 8 2 0.75 v\n";
+  output << "V 7 VIA1 VIA1_TEST VDD 1 2 2 0.1 0.2 0.5 7 0 0 0 r RULE LANDING 10_1\n";
+  output.close();
+
+  iemir::RedHawkResNetwork network = iemir::RedHawkResNetworkReader::read(file_path.string());
+  const iemir::RedHawkWireSegmentRecord& explicit_segment = network.wire_segments.at(0);
+  const iemir::RedHawkViaRecord& via = network.vias.at(0);
+  return network.wire_segments.size() == 1 && network.vias.size() == 1 && explicit_segment.id == "10_1"
+         && explicit_segment.layer_name == "MET1" && explicit_segment.net_name == "VDD"
+         && std::abs(explicit_segment.resistance_ohm - 0.25) <= 1.0e-18 && via.id == "7" && via.layer_name == "VIA1"
+         && via.net_name == "VDD" && via.cut_num == 2 && via.connected_wire_segment_ids == std::vector<std::string>{"10_1"}
+         && std::abs(via.resistance_ohm - 0.5) <= 1.0e-18;
+}
+
+bool checkImportedPinAreaInjection()
+{
+  bool is_pass = true;
+  // Nonuniform extraction intervals must yield 1:4:3 load weights at 10, 11,
+  // and 14. A second pin introduces a subdivision at 12; its insertion order
+  // must not alter the first pin's physical load distribution.
+  for (bool filler_first : {false, true}) {
+    for (bool pin_specific : {false, true}) {
+      for (int32_t source_x : {0, 10}) {
+        iemir::PowerNet net;
+        net.set_net_name("VDD");
+        net.set_type(iemir::PowerNetType::kPower);
+        net.set_has_explicit_parasitics(true);
+        std::vector<int32_t> coordinates{0, 10, 11, 14, 20};
+        for (std::size_t i = 1; i < coordinates.size(); ++i) {
+          iemir::PowerWireSegment wire;
+          wire.set_layer_idx(1);
+          wire.set_layer_name("MET1");
+          wire.set_first_x(coordinates[i - 1]);
+          wire.set_first_y(0);
+          wire.set_second_x(coordinates[i]);
+          wire.set_second_y(0);
+          wire.set_width(2);
+          wire.set_resistance(coordinates[i] - coordinates[i - 1]);
+          net.get_wire_segment_list().push_back(wire);
+        }
+        iemir::PowerPin load;
+        load.set_layer_idx(1);
+        load.set_instance_id(1);
+        load.set_pin_name("U1:VDD");
+        load.set_x(12);
+        load.set_y(0);
+        load.set_low_x(9);
+        load.set_high_x(15);
+        load.set_low_y(-1);
+        load.set_high_y(1);
+        iemir::PowerPin filler = load;
+        filler.set_instance_id(2);
+        filler.set_pin_name("U2:VDD");
+        filler.set_low_x(12);
+        filler.set_high_x(12);
+        net.get_pin_list() = filler_first ? std::vector<iemir::PowerPin>{filler, load} : std::vector<iemir::PowerPin>{load, filler};
+        iemir::PowerSource source;
+        source.set_name("PLOC");
+        source.set_net_name("VDD");
+        source.set_net_type(iemir::PowerNetType::kPower);
+        source.set_layer_name("MET1");
+        source.set_x(source_x);
+        source.set_y(0);
+        EMIRDM.getDatabase().get_power_net_map()["VDD"] = net;
+        EMIRDM.getDatabase().get_power_source_list().push_back(source);
+        iemir::InstancePower power;
+        power.set_instance_id(1);
+        power.set_voltage(1.0);
+        power.set_average_current(8e-6);
+        if (pin_specific) {
+          power.get_average_current_by_pin_name_map()["VDD"] = 8e-6;
+        }
+        EMIRDM.getDatabase().get_instance_power_map()[1] = power;
+        iemir::GraphBuilder::initInst();
+        EMIRGB.build();
+        iemir::GraphBuilder::destroyInst();
+        iemir::IRAnalyzer::initInst();
+        EMIRIA.analyze();
+        iemir::IRAnalyzer::destroyInst();
+        auto& graph = EMIRDM.getDatabase().get_power_graph_map().at("VDD");
+        for (auto [x, expected_current] : std::map<int32_t, double>{{10, -1e-6}, {11, -4e-6}, {14, -3e-6}, {12, 0.0}}) {
+          auto id = graph.get_coordinate_node_id_map().at(std::make_tuple(1, x, 0));
+          is_pass = is_pass && std::abs(graph.get_node_list()[id].get_current() - expected_current) < 1e-15;
+        }
+        auto endpoint = graph.get_coordinate_node_id_map().at(std::make_tuple(1, 14, 0));
+        double expected_drop = source_x == 0 ? 96e-6 : 16e-6;
+        is_pass = is_pass && std::abs(graph.get_node_list()[endpoint].get_voltage() - (1.0 - expected_drop)) < 1e-12;
+        EMIRDM.getDatabase().get_instance_power_map().clear();
+        EMIRDM.getDatabase().get_power_source_list().clear();
+        EMIRDM.getDatabase().get_power_net_map().clear();
+        EMIRDM.getDatabase().get_power_graph_map().clear();
+      }
+    }
+  }
+  return is_pass;
+}
+
+bool checkViaUsesConnectedResistorJunction()
+{
+  iemir::RedHawkWireSegmentRecord rail;
+  rail.id = "rail";
+  rail.layer_name = "MET4";
+  rail.net_name = "VDD";
+  rail.first_x_um = rail.second_x_um = 235.0;
+  rail.first_y_um = 231.0;
+  rail.second_y_um = 233.8;
+  iemir::RedHawkWireSegmentRecord pad = rail;
+  pad.id = "pad";
+  pad.first_y_um = 233.8;
+  pad.second_y_um = 233.84;
+  std::unordered_map<std::string, const iemir::RedHawkWireSegmentRecord*> segments{{"rail", &rail}, {"pad", &pad}};
+  iemir::RedHawkViaRecord via;
+  via.net_name = "VDD";
+  via.x_um = 234.75;
+  via.y_um = 233.84;
+  for (const auto& ids : {std::vector<std::string>{"rail", "pad"}, std::vector<std::string>{"pad", "rail"}}) {
+    via.connected_wire_segment_ids = ids;
+    auto coordinate = iemir::RedHawkResNetworkReader::connectionCoordinate(via, segments, "MET4");
+    if (!coordinate || coordinate->first != 235.0 || coordinate->second != 233.8) {
+      return false;
+    }
+  }
+  // A single connected segment still uses projection; an unrelated layer
+  // must not acquire a fabricated connection.
+  via.connected_wire_segment_ids = {"pad"};
+  auto coordinate = iemir::RedHawkResNetworkReader::connectionCoordinate(via, segments, "MET4");
+  return coordinate && coordinate->first == 235.0 && coordinate->second == 233.84
+         && !iemir::RedHawkResNetworkReader::connectionCoordinate(via, segments, "MET2");
+}
+
 }  // namespace
 
-int main()
+int main(int argc, char* argv[])
 {
+  if (argc > 1) {
+    try {
+      for (int argument_index = 1; argument_index < argc; argument_index++) {
+        iemir::RedHawkResNetworkReader::read(argv[argument_index]);
+      }
+    } catch (const std::exception& error) {
+      std::cerr << error.what() << "\n";
+      return 1;
+    }
+    return 0;
+  }
+
   iemir::Logger::initInst();
   iemir::DataManager::initInst();
 
+  std::filesystem::path report_directory_path = std::filesystem::temp_directory_path() / "iemir_ir_em_test";
+  std::filesystem::remove_all(report_directory_path);
+  std::filesystem::create_directories(report_directory_path);
+  EMIRDM.getConfig().ia_temp_directory_path = report_directory_path.string() + "/";
+
+  bool is_pass = checkPTPXPowerReader(report_directory_path) && checkRedHawkResNetworkReader(report_directory_path) && checkShiftedViaGraph(report_directory_path)
+                 && checkPointSourceDoesNotShortNearbySegment() && checkImportedPinAreaInjection() && checkViaUsesConnectedResistorJunction()
+                 && checkSubMicroampLoad();
+  EMIRDM.getDatabase().set_design_name("test_design");
+  EMIRDM.getDatabase().set_micron_dbu(1000);
+  iemir::EMMetalRule metal_rule;
+  metal_rule.set_name("MET1");
+  metal_rule.set_em_limit_ma_per_um(1.0);
+  EMIRDM.getDatabase().get_em_tech().get_metal_rule_map()["MET1"] = metal_rule;
   iemir::InstancePower instance_power;
   instance_power.set_instance_id(1);
   instance_power.set_voltage(1.0);
   instance_power.set_internal_power(1.0);
+  instance_power.set_average_current(1.0);
+  instance_power.get_average_current_by_pin_name_map()["VDD"] = 1.0;
   EMIRDM.getDatabase().get_instance_power_map()[instance_power.get_instance_id()] = instance_power;
   EMIRDM.getDatabase().get_power_graph_map()["VDD"] = buildPowerGraph("VDD", iemir::PowerNetType::kPower);
   EMIRDM.getDatabase().get_power_graph_map()["VSS"] = buildPowerGraph("VSS", iemir::PowerNetType::kGround);
@@ -100,17 +451,19 @@ int main()
   EMIREA.analyze();
   iemir::EMAnalyzer::destroyInst();
 
-  bool is_pass
-      = checkPowerGraph(EMIRDM.getDatabase().get_power_graph_map()["VDD"], 0.0) && checkPowerGraph(EMIRDM.getDatabase().get_power_graph_map()["VSS"], 1.0);
-  std::filesystem::path report_directory_path = std::filesystem::temp_directory_path() / "iemir_ir_em_test";
-  std::filesystem::remove_all(report_directory_path);
-  std::filesystem::create_directories(report_directory_path);
+  is_pass = is_pass && checkPowerGraph(EMIRDM.getDatabase().get_power_graph_map()["VDD"], 0.0)
+            && checkPowerGraph(EMIRDM.getDatabase().get_power_graph_map()["VSS"], 1.0);
+  is_pass = is_pass && checkReport((report_directory_path / "solver_diagnostics.csv").string(), "relative_l2_residual");
   EMIRDM.getConfig().er_temp_directory_path = report_directory_path.string() + "/";
   iemir::EMIRReporter::initInst();
   EMIRER.report();
   iemir::EMIRReporter::destroyInst();
-  is_pass = is_pass && checkReport((report_directory_path / "ir.rpt").string(), "########## IR report #################")
-            && checkReport((report_directory_path / "em.rpt").string(), "########## EM analysis ###############");
+  is_pass = is_pass && checkReport((report_directory_path / "ir.rpt").string(), "#voltage #ideal_volt")
+            && checkReport((report_directory_path / "em.rpt").string(), "# For wires: #layer #end-to-end_coordinates #EM_Ratio #Current_value")
+            && checkReport((report_directory_path / "test_design.ir.worst").string(), "#x_y_location")
+            && checkReport((report_directory_path / "test_design.em.worst").string(), "#current")
+            && checkReport((report_directory_path / "test_design.res_network").string(), "em_limit(A)")
+            && checkReport((report_directory_path / "test_design.res_network").string(), "100000");
   std::filesystem::remove_all(report_directory_path);
 
   iemir::DataManager::destroyInst();


### PR DESCRIPTION
1. 接入 PTPX 实例功耗  
   读取标准化功耗 TSV，按实例名匹配 DEF，校验功耗分量、电流和实例功耗覆盖率。iEMIR 直接使用这份功耗，不再需要运行 iSTA 计算功耗。

2. 导入 RedHawk 电阻网络  
   读取 `..res_network` 中的导线电阻、via 电阻及连接信息，用于构建 iEMIR 求解网络。

3. 修正电流注入和电源连接  
   按引脚覆盖区域及线段长度分配负载电流；修正 PLOC 接入位置，避免将附近线段错误短接；修正小电流负载的处理。

4. 修正 via 的连接与报告位置  
   分别保存 via 在上下金属层的电气连接点和原始物理坐标。建图使用电气连接点，报告使用物理坐标，解决连接节点和比较坐标错位的问题。

5. 完善 IR/EM 计算及输出  
   读取工艺 EM 限值和覆盖规则，结合导线宽度、via cut 数量及面积计算 EM 比例，按配置阈值判断超限。提高电压、电流和电阻报告精度，增加方程残差及电流守恒诊断。

6. 收敛修改范围和接口  
   撤下 iSTA 及其 Tcl/Python 入口的默认解释扩展；删除未使用的 PG SPEF 导入及直接链接依赖；删除自动生成理想电源的兼容分支。功耗入口统一为 `-ptpx_instance_power_file_path`，无效 PLOC/IO 电源时明确报错，不兼容旧 EMIR 接口。