### PR TITLE
fix(place): preserve macro writeback identity

### DIFF
--- a/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.cpp
+++ b/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.cpp
@@ -156,7 +156,7 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
     _node_is_hard_macro.push_back(is_hard_macro);
     _macro_writeback_candidate.push_back(is_macro_writeback_candidate);
     if (is_macro_writeback_candidate) {
-      _macro_writeback_candidates.push_back({id, name, instance});
+      _macro_writeback_candidates.push_back({id, name, instance->get_id()});
     }
     // map new node to original index
     if (mNode2idbID.count(name)) {
@@ -600,7 +600,7 @@ std::size_t PyPlaceDB::writeMacroPlacementBack(
       throw std::invalid_argument("Macro placement writeback coordinates must be finite int32-compatible values");
     }
     updates.push_back(
-        {candidate.instance_name, candidate.instance, static_cast<int32_t>(candidate_x), static_cast<int32_t>(candidate_y)});
+        {candidate.instance_name, candidate.instance_id, static_cast<int32_t>(candidate_x), static_cast<int32_t>(candidate_y)});
   }
   return _db->write_selected_placement_back(updates);
 }

--- a/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.h
+++ b/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.h
@@ -141,7 +141,7 @@ struct PyPlaceDB
   {
     index_type node_id;
     std::string instance_name;
-    idb::IdbInstance* instance;
+    uint64_t instance_id;
   };
 
   idm::DataManager* _db = nullptr;

--- a/src/platform/data_manager/idm.cpp
+++ b/src/platform/data_manager/idm.cpp
@@ -243,7 +243,7 @@ std::size_t DataManager::write_selected_placement_back(const std::vector<Instanc
     if (instance == nullptr) {
       throw std::runtime_error("Selected placement instance no longer exists: " + update.instance_name);
     }
-    if (instance != update.expected_instance) {
+    if (instance->get_id() != update.expected_instance_id) {
       throw std::runtime_error("Selected placement no longer refers to the same instance: " + update.instance_name);
     }
     auto* cell_master = instance->get_cell_master();

--- a/src/platform/data_manager/idm.h
+++ b/src/platform/data_manager/idm.h
@@ -56,7 +56,7 @@ namespace idm {
 struct InstancePlacementUpdate
 {
   std::string instance_name;
-  IdbInstance* expected_instance;
+  uint64_t expected_instance_id;
   int32_t x;
   int32_t y;
 };


### PR DESCRIPTION
## Summary

- Store the stable iDB instance ID in macro writeback candidates instead of a raw instance pointer.
- Reject a delete-and-recreate operation with the same instance name before applying stale placement data.

A raw pointer is not a stable identity: the allocator can reuse the deleted instance's address, causing stale macro placement data to be written to the replacement instance.

## Validation

- Rebuilt `ecc-tools-bin` from source.
- `nix develop -c uv run pytest test/tools/ecc/test_pyplacedb_macro_writeback.py -q` (ECC integration workspace)