### PR TITLE
fix(place): default unplaced macro orientation to N on writeback

### DIFF
--- a/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.cpp
+++ b/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.cpp
@@ -156,7 +156,13 @@ void PyPlaceDB::set(idm::DataManager* db, int numRoutingGridsX, int numRoutingGr
     _node_is_hard_macro.push_back(is_hard_macro);
     _macro_writeback_candidate.push_back(is_macro_writeback_candidate);
     if (is_macro_writeback_candidate) {
-      _macro_writeback_candidates.push_back({id, name, instance->get_id()});
+      // Unplaced macros carry kNone; default them to N/R0 so the placement
+      // written back (and the DEF saved from it) carries an orientation.
+      auto orient = instance->get_orient();
+      if (orient == IdbOrient::kNone) {
+        orient = IdbOrient::kN_R0;
+      }
+      _macro_writeback_candidates.push_back({id, name, instance->get_id(), orient});
     }
     // map new node to original index
     if (mNode2idbID.count(name)) {
@@ -599,8 +605,8 @@ std::size_t PyPlaceDB::writeMacroPlacementBack(
         || checked_y > static_cast<double>(std::numeric_limits<int32_t>::max())) {
       throw std::invalid_argument("Macro placement writeback coordinates must be finite int32-compatible values");
     }
-    updates.push_back(
-        {candidate.instance_name, candidate.instance_id, static_cast<int32_t>(candidate_x), static_cast<int32_t>(candidate_y)});
+    updates.push_back({candidate.instance_name, candidate.instance_id, static_cast<int32_t>(candidate_x),
+                       static_cast<int32_t>(candidate_y), candidate.orient});
   }
   return _db->write_selected_placement_back(updates);
 }

--- a/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.h
+++ b/src/interface/python/py_imp/idb_to_imp_db/PyPlaceDB.h
@@ -142,6 +142,7 @@ struct PyPlaceDB
     index_type node_id;
     std::string instance_name;
     uint64_t instance_id;
+    idb::IdbOrient orient;
   };
 
   idm::DataManager* _db = nullptr;

--- a/src/platform/data_manager/idm.cpp
+++ b/src/platform/data_manager/idm.cpp
@@ -255,7 +255,7 @@ std::size_t DataManager::write_selected_placement_back(const std::vector<Instanc
 
   for (std::size_t index = 0; index < updates.size(); ++index) {
     const auto& update = updates[index];
-    commitPlacement(instances[index], update.x, update.y, instances[index]->get_orient());
+    commitPlacement(instances[index], update.x, update.y, update.orient);
   }
   return updates.size();
 }

--- a/src/platform/data_manager/idm.h
+++ b/src/platform/data_manager/idm.h
@@ -59,6 +59,7 @@ struct InstancePlacementUpdate
   uint64_t expected_instance_id;
   int32_t x;
   int32_t y;
+  IdbOrient orient;
 };
 
 class DataManager


### PR DESCRIPTION
## Problem

Unplaced macros carry `IdbOrient::kNone`, and the DEF writer emits an empty orient string for it, so macro placement results were saved as `+ PLACED ( x y )` without an orientation. Downstream steps and the foundation extractor had to implicitly treat the missing orientation as R0.

## Change

Capture a default orientation when a macro writeback candidate is registered (`kNone` -> `kN_R0`), and carry it through `InstancePlacementUpdate` so `write_selected_placement_back` commits it via `commitPlacement`. The saved DEF then carries the orientation.

Geometry is unchanged: `IdbOrientTransform` already treats `kNone` as R0, so this only makes the state explicit.

## Verification

- End-to-end: DEF with an unplaced macro plus a programmatically created `kNone` macro -> `write_macro_placement_back` -> `def_save`; both components come out as `+ PLACED ( x y ) N` at the new coordinates.
- `-fsyntax-only` pass on `PyPlaceDB.cpp` and `idm.cpp` after resolving with #227.