### PR TITLE
refactor(iFP): remove macro placement mode

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -7,26 +7,9 @@ runs:
     - name: Install system dependencies
       shell: bash
       run: |
-        install_dnf_packages() {
-          local attempt
-          for attempt in 1 2 3; do
-            if dnf --refresh install -y "$@"; then
-              return 0
-            fi
-
-            if [[ "$attempt" -lt 3 ]]; then
-              echo "dnf install failed on attempt ${attempt}/3; refreshing metadata before retrying"
-              dnf clean all
-              sleep "$((attempt * 10))"
-            fi
-          done
-
-          return 1
-        }
-
-        install_dnf_packages epel-release
+        dnf install -y epel-release
         dnf config-manager --set-enabled crb || true
-        install_dnf_packages \
+        dnf install -y \
           cmake ninja-build pkgconfig patchelf mold lld curl gcc-c++ \
           cairo-devel gflags-devel glog-devel \
           flex flex-devel bison eigen3-devel gtest-devel \

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -7,9 +7,26 @@ runs:
     - name: Install system dependencies
       shell: bash
       run: |
-        dnf install -y epel-release
+        install_dnf_packages() {
+          local attempt
+          for attempt in 1 2 3; do
+            if dnf --refresh install -y "$@"; then
+              return 0
+            fi
+
+            if [[ "$attempt" -lt 3 ]]; then
+              echo "dnf install failed on attempt ${attempt}/3; refreshing metadata before retrying"
+              dnf clean all
+              sleep "$((attempt * 10))"
+            fi
+          done
+
+          return 1
+        }
+
+        install_dnf_packages epel-release
         dnf config-manager --set-enabled crb || true
-        dnf install -y \
+        install_dnf_packages \
           cmake ninja-build pkgconfig patchelf mold lld curl gcc-c++ \
           cairo-devel gflags-devel glog-devel \
           flex flex-devel bison eigen3-devel gtest-devel \

--- a/src/operation/iFP/interface/FPInterface.cpp
+++ b/src/operation/iFP/interface/FPInterface.cpp
@@ -225,13 +225,8 @@ void FPInterface::debugInputMacro(std::map<std::string, std::any> config_map)
 
 void FPInterface::inputMacroPlacement(const std::string& macro_place_file_path)
 {
-  Config& config = FPDM.getConfig();
   if (macro_place_file_path.empty()) {
-    if (config.macro_placement_mode == PlacementMode::kAuto) {
-      return;
-    }
-    FPLOG.error(Loc::current(), "Macro placer mode is '", GetPlacementModeName()(config.macro_placement_mode),
-                "', but macro_placer.file_path is empty!");
+    return;
   }
 
   Database& database = FPDM.getDatabase();
@@ -241,10 +236,6 @@ void FPInterface::inputMacroPlacement(const std::string& macro_place_file_path)
     instance_map[instance.get_name()] = &instance;
     macro_num += instance.get_macro() ? 1 : 0;
   }
-  if (config.macro_placement_mode == PlacementMode::kAuto) {
-    FPLOG.info(Loc::current(), "Macro placer auto mode currently uses placement file '", macro_place_file_path, "'.");
-  }
-
   int32_t micron_dbu = database.get_micron_dbu();
   if (micron_dbu <= 0) {
     FPLOG.error(Loc::current(), "Cannot load macro placement with an invalid micron DBU value: ", micron_dbu, ".");
@@ -396,7 +387,6 @@ void FPInterface::wrapConfig(std::map<std::string, std::any>& config_map)
   Config& config = FPDM.getConfig();
   config.temp_directory_path = "./fp_temp_directory";
   config.thread_number = 128;
-  config.macro_placement_mode = PlacementMode::kAuto;
   config.macro_placement_halo = -1.0;
   config.macro_routing_halo = -1.0;
   config.input_macro_path.clear();
@@ -442,7 +432,6 @@ void FPInterface::wrapConfig(std::map<std::string, std::any>& config_map)
   config.thread_number = std::max(ifp_json["thread_number"].get<int32_t>(), 1);
 
   nlohmann::json& macro_placer_json = config_json["macro_placer"];
-  config.macro_placement_mode = GetPlacementModeByName()(macro_placer_json["mode"].get<std::string>());
   std::string macro_file_path = macro_placer_json.value("file_path", "");
   config.input_macro_path = macro_file_path.empty() ? "" : FPUTIL.getAbsolutePath(config_directory_path, macro_file_path);
   config.macro_placement_halo = macro_placer_json["macro_placement_halo"].get<double>();

--- a/src/operation/iFP/source/data_manager/DataManager.cpp
+++ b/src/operation/iFP/source/data_manager/DataManager.cpp
@@ -161,8 +161,8 @@ void DataManager::printConfig()
   FPLOG.info(Loc::current(), FPUTIL.getSpaceByTabNum(1), "thread_number");
   FPLOG.info(Loc::current(), FPUTIL.getSpaceByTabNum(2), _config.thread_number);
   FPLOG.info(Loc::current(), FPUTIL.getSpaceByTabNum(1), "macro_placer");
-  FPLOG.info(Loc::current(), FPUTIL.getSpaceByTabNum(2), "mode: ", GetPlacementModeName()(_config.macro_placement_mode),
-             ", placement_halo: ", _config.macro_placement_halo, ", routing_halo: ", _config.macro_routing_halo);
+  FPLOG.info(Loc::current(), FPUTIL.getSpaceByTabNum(2), "placement_halo: ", _config.macro_placement_halo,
+             ", routing_halo: ", _config.macro_routing_halo);
   FPLOG.info(Loc::current(), FPUTIL.getSpaceByTabNum(2), "input_path: ", _config.input_macro_path);
 
   FPLOG.info(Loc::current(), FPUTIL.getSpaceByTabNum(1), "die");

--- a/src/operation/iFP/source/data_manager/advance/Config.hpp
+++ b/src/operation/iFP/source/data_manager/advance/Config.hpp
@@ -35,10 +35,9 @@ class Config
   // **********        FP         ********** //
   std::string temp_directory_path;                         // required
   int32_t thread_number;                                   // optional
-  PlacementMode macro_placement_mode;                      // required
   double macro_placement_halo;                             // optional
   double macro_routing_halo;                               // optional
-  std::string input_macro_path;                            // optional
+  std::string input_macro_path;                            // optional; non-empty loads macro placement file
   DieMode die_mode;                                        // optional
   std::string die_site_name;                               // optional
   double die_aspect_ratio;                                 // optional

--- a/test/fixtures/gcd/config/floorplan_ecc.json
+++ b/test/fixtures/gcd/config/floorplan_ecc.json
@@ -4,7 +4,6 @@
         "thread_number": 16
     },
     "macro_placer": {
-        "mode": "auto",
         "file_path": "",
         "macro_placement_halo": 3.0,
         "macro_routing_halo": 3.0


### PR DESCRIPTION
## Summary
- remove the obsolete `macro_placer.mode` configuration and placement-mode state
- treat an empty macro placement file as a no-op
- update the floorplan fixture accordingly